### PR TITLE
Fix metrics endpoint

### DIFF
--- a/framework/systemendpoint/module.go
+++ b/framework/systemendpoint/module.go
@@ -17,7 +17,7 @@ type (
 
 // Configure DI
 func (m *Module) Configure(injector *dingo.Injector) {
-	flamingo.BindEventSubscriber(injector).To(&application.SystemServer{})
+	flamingo.BindEventSubscriber(injector).To(&application.SystemServer{}).In(dingo.Singleton)
 }
 
 // DefaultConfig for the module


### PR DESCRIPTION
metrics endpoint is not available on multi-area setups with prefix router.
The map binding to systemendpoit has to be done on each call of opencensus' Configure().