### PR TITLE
fix failing routes and handler commands

### DIFF
--- a/framework/systemendpoint/Readme.md
+++ b/framework/systemendpoint/Readme.md
@@ -1,6 +1,6 @@
 # Systemendpoint module
 
-This package provides a second endpoint intended for internal use.
+This package provides a second endpoint intended for non public use.
 
 You can register simple `http.Handler` to a desired route via Dingo map binding:
 
@@ -11,4 +11,4 @@ injector.BindMap((*domain.Handler)(nil), "/my/route").To(&myHandler{})
 This module will then bring up an HTTP Server at the configured address `systemendpoint.serviceAddr` 
 which defaults to `:13210` serving all bound routes.
 
-The server will be started on `flamingo.AppStartupEvent` and shut down on `flamingo.AppShutdownEvent`.
+The server will be started on `flamingo.ServerStartEvent` and shut down on `flamingo.ServerShutdownEvent`.

--- a/framework/web/routescmd.go
+++ b/framework/web/routescmd.go
@@ -43,7 +43,12 @@ func HandlerCmd(router *Router, area *config.Area) *cobra.Command {
 }
 
 func dumpRoutes(router *Router, area *config.Area) {
-	// router.Init(area)
+	if router == nil {
+		return
+	}
+	if router.routerRegistry == nil {
+		router.Handler()
+	}
 	fmt.Println()
 	fmt.Println("***************************************************************************")
 	fmt.Println(" Route                						| Handler-Name:               ")
@@ -56,6 +61,12 @@ func dumpRoutes(router *Router, area *config.Area) {
 }
 
 func dumpHandler(router *Router, area *config.Area) {
+	if router == nil {
+		return
+	}
+	if router.routerRegistry == nil {
+		router.Handler()
+	}
 	// router.Init(area)
 	fmt.Println()
 	fmt.Println("***************************************************************************")


### PR DESCRIPTION
routes and handler commands fail with nil pointer runtime error (tries to access router.routerRegistry  )

probably due to former refactorings of router.

(We should add functional tests for the commands)