### PR TITLE
Commands not stopping

### DIFF
--- a/framework/cmd/module.go
+++ b/framework/cmd/module.go
@@ -64,7 +64,7 @@ func (m *Module) Configure(injector *dingo.Injector) {
 
 			return rootCmd
 		},
-	)
+	).In(dingo.Singleton)
 }
 
 // DefaultConfig specifies the command name


### PR DESCRIPTION
Currently all commands are not stopping unless you hit STRG-C

This is because the rootcommand inherits the PersistentPostRun which always blocks until termination signal is send.

Proposal A) 
We can send own signal in all commands that should stop immediatelly (see commit)

Proposal B)
The root command should not block
Instead it should just trigger the ShutdownEvent in its PersistentPostRun
Then it is the job of the "serve" command to handle the interruption


Thoughts?