### PR TITLE
locale: add support for BigFloat in number format template function

### DIFF
--- a/core/locale/interfaces/templatefunctions/numberFormat.go
+++ b/core/locale/interfaces/templatefunctions/numberFormat.go
@@ -2,6 +2,8 @@ package templatefunctions
 
 import (
 	"context"
+	"math/big"
+
 	"flamingo.me/flamingo/v3/framework/flamingo"
 
 	"github.com/leekchan/accounting"
@@ -30,7 +32,7 @@ func (nff *NumberFormatFunc) Inject(
 	nff.logger = logger
 }
 
-// Func as implementation of debug method
+// Func returns the template function for formatting numbers
 func (nff *NumberFormatFunc) Func(context.Context) interface{} {
 	return func(value interface{}, params ...int) string {
 
@@ -44,6 +46,11 @@ func (nff *NumberFormatFunc) Func(context.Context) interface{} {
 				nff.logger.Error(err)
 			}
 		}()
+
+		valueBigFloat, ok := value.(*big.Float)
+		if ok {
+			return accounting.FormatNumberBigFloat(valueBigFloat, precision, nff.thousand, nff.decimal)
+		}
 
 		return accounting.FormatNumber(value, precision, nff.thousand, nff.decimal)
 	}

--- a/core/locale/interfaces/templatefunctions/numberFormat_test.go
+++ b/core/locale/interfaces/templatefunctions/numberFormat_test.go
@@ -1,0 +1,89 @@
+package templatefunctions_test
+
+import (
+	"context"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"flamingo.me/flamingo/v3/core/locale/interfaces/templatefunctions"
+	"flamingo.me/flamingo/v3/framework/flamingo"
+)
+
+func TestNumberFormatFunc_Func(t *testing.T) {
+	type fields struct {
+		precision float64
+		decimal   string
+		thousand  string
+		logger    flamingo.Logger
+	}
+	type args struct {
+		value interface{}
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   interface{}
+	}{
+		{
+			name: "int",
+			fields: fields{
+				precision: 1,
+				decimal:   ".",
+				thousand:  ",",
+				logger:    flamingo.NullLogger{},
+			},
+			args: args{
+				value: 55,
+			},
+			want: "55.0",
+		},
+		{
+			name: "float64",
+			fields: fields{
+				precision: 3,
+				decimal:   ",",
+				thousand:  "",
+				logger:    flamingo.NullLogger{},
+			},
+			args: args{
+				value: float64(55),
+			},
+			want: "55,000",
+		},
+		{
+			name: "BigFloat",
+			fields: fields{
+				precision: 2,
+				decimal:   ".",
+				thousand:  ",",
+				logger:    flamingo.NullLogger{},
+			},
+			args: args{
+				value: big.NewFloat(5500.0),
+			},
+			want: "5,500.00",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nff := &templatefunctions.NumberFormatFunc{}
+			nff.Inject(tt.fields.logger, &struct {
+				Precision float64 `inject:"config:locale.numbers.precision"`
+				Decimal   string  `inject:"config:locale.numbers.decimal"`
+				Thousand  string  `inject:"config:locale.numbers.thousand"`
+			}{
+				Precision: tt.fields.precision,
+				Decimal:   tt.fields.decimal,
+				Thousand:  tt.fields.thousand,
+			})
+
+			templateFunc := nff.Func(context.Background()).(func(value interface{}, params ...int) string)
+
+			if got := templateFunc(tt.args.value); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NumberFormatFunc.Func() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Template function for formatting numbers currently can't handle big.Float. This PR changes this and adds according test cases.