### PR TITLE
handle accesstoken empty edge cases

### DIFF
--- a/core/oauth/Readme.md
+++ b/core/oauth/Readme.md
@@ -103,3 +103,8 @@ html
   ...
   a(href=url("auth.callback")) Login
 ```
+
+
+## Debugging
+
+Start flamingo with the environment variable "OAUTHDEBUG" - to get raw dump of http request and responses to the configured oauth provider logged to stdout.

--- a/core/oauth/application/authmanager.go
+++ b/core/oauth/application/authmanager.go
@@ -378,6 +378,7 @@ func (am *AuthManager) StoreTokenDetails(session *web.Session, oauth2Token *oaut
 	session.Store(keyToken, oauth2Token)
 	session.Store(keyRawIDToken, rawToken)
 	session.Store(keyTokenExtras, tokenExtras)
+	return nil
 }
 
 // DeleteTokenDetails deletes all token related data from session

--- a/core/oauth/application/authmanager.go
+++ b/core/oauth/application/authmanager.go
@@ -245,6 +245,25 @@ func (am *AuthManager) createClaimSetFromMapping(topLevelName string, configurat
 	return claimSet
 }
 
+
+// AccessToken - used to get access token
+func (am *AuthManager) AccessToken(ctx context.Context, session *web.Session) (string, error) {
+	auth, err := am.Auth(ctx, session)
+	if err != nil {
+		return "", err
+	}
+	t, err := auth.TokenSource.Token()
+	if err != nil {
+		return "", err
+	}
+	if t.AccessToken == "" {
+		err := errors.New("no accesstoken")
+		am.logger.Error(err)
+		return "", err
+	}
+	return t.AccessToken, nil
+}
+
 // ExtractRawIDToken from the provided (fresh) oatuh2token
 func (am *AuthManager) ExtractRawIDToken(oauth2Token *oauth2.Token) (string, error) {
 	// Extract the ID Token from OAuth2 token.

--- a/core/oauth/interfaces/callback_controller.go
+++ b/core/oauth/interfaces/callback_controller.go
@@ -66,7 +66,7 @@ func (cc *CallbackController) Get(ctx context.Context, request *web.Request) web
 		cc.logger.Error("core.auth.callback Missing parameter", err)
 		return cc.responder.ServerError(errors.WithStack(err))
 	} else if code != "" {
-		oauth2Token, err := cc.authManager.OAuth2Config(ctx, request).Exchange(ctx, code)
+		oauth2Token, err := cc.authManager.OAuth2Config(ctx, request).Exchange(cc.authManager.OAuthCtx(ctx), code)
 		if err != nil {
 			cc.logger.Error("core.auth.callback Error OAuth2Config Exchange", err)
 			return cc.responder.ServerError(errors.WithStack(err))

--- a/core/oauth/interfaces/callback_controller.go
+++ b/core/oauth/interfaces/callback_controller.go
@@ -2,6 +2,7 @@ package interfaces
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 
 	"flamingo.me/flamingo/v3/core/oauth/application"
@@ -49,7 +50,7 @@ func (cc *CallbackController) Get(ctx context.Context, request *web.Request) web
 	defer cc.authManager.DeleteAuthState(request.Session())
 
 	if state, ok := cc.authManager.LoadAuthState(request.Session()); !ok || state != request.Request().URL.Query().Get("state") {
-		cc.logger.Error("Invalid State", state, request.Request().URL.Query().Get("state"))
+		cc.logger.Error(fmt.Sprintf("Invalid State - expected: %v  got: %v", state, request.Request().URL.Query().Get("state")))
 		return cc.responder.ServerError(errors.New("Invalid State"))
 	}
 

--- a/core/oauth/interfaces/callback_controller.go
+++ b/core/oauth/interfaces/callback_controller.go
@@ -6,7 +6,6 @@ import (
 
 	"flamingo.me/flamingo/v3/core/oauth/application"
 	"flamingo.me/flamingo/v3/core/oauth/domain"
-	"flamingo.me/flamingo/v3/framework/config"
 	"flamingo.me/flamingo/v3/framework/flamingo"
 	"flamingo.me/flamingo/v3/framework/web"
 	"github.com/pkg/errors"

--- a/core/oauth/interfaces/callback_controller.go
+++ b/core/oauth/interfaces/callback_controller.go
@@ -71,6 +71,10 @@ func (cc *CallbackController) Get(ctx context.Context, request *web.Request) web
 			cc.logger.Error("core.auth.callback Error OAuth2Config Exchange", err)
 			return cc.responder.ServerError(errors.WithStack(err))
 		}
+		if oauth2Token.AccessToken == "" {
+			cc.logger.Error("core.auth.callback Error OAuth2Config Exchange - empty Access Token!")
+			return cc.responder.ServerError(errors.New("empty Access Token"))
+		}
 
 		var extras []string
 		err = cc.tokenExtras.MapInto(&extras)

--- a/core/oauth/interfaces/callback_controller.go
+++ b/core/oauth/interfaces/callback_controller.go
@@ -68,7 +68,7 @@ func (cc *CallbackController) Get(ctx context.Context, request *web.Request) web
 			return cc.responder.ServerError(errors.WithStack(err))
 		}
 
-		err = cc.authManager.StoreTokenDetails(request.Session(), oauth2Token)
+		err = cc.authManager.StoreTokenDetails(ctx,request.Session(), oauth2Token)
 		if err != nil {
 			cc.logger.Error("core.auth.callback Error", err)
 			return cc.responder.ServerError(errors.WithStack(err))

--- a/core/oauth/interfaces/callback_controller.go
+++ b/core/oauth/interfaces/callback_controller.go
@@ -67,10 +67,6 @@ func (cc *CallbackController) Get(ctx context.Context, request *web.Request) web
 			cc.logger.Error("core.auth.callback Error OAuth2Config Exchange", err)
 			return cc.responder.ServerError(errors.WithStack(err))
 		}
-		if oauth2Token.AccessToken == "" {
-			cc.logger.Error("core.auth.callback Error OAuth2Config Exchange - empty Access Token!")
-			return cc.responder.ServerError(errors.New("empty Access Token"))
-		}
 
 		err = cc.authManager.StoreTokenDetails(request.Session(), oauth2Token)
 		if err != nil {

--- a/framework/web/router.go
+++ b/framework/web/router.go
@@ -121,7 +121,7 @@ func (r *Router) Handler() http.Handler {
 		routerRegistry: r.routerRegistry,
 		filter:         r.filterProvider(),
 		eventRouter:    r.eventRouter,
-		logger:         r.logger,
+		logger:         r.logger.WithField(flamingo.LogKeyModule,"web").WithField(flamingo.LogKeyCategory,"handler"),
 		sessionStore:   r.sessionStore,
 		sessionName:    r.sessionName,
 		prefix:         strings.TrimRight(r.base.Path, "/"),

--- a/framework/web/router_test.go
+++ b/framework/web/router_test.go
@@ -11,15 +11,16 @@ import (
 
 	"github.com/gorilla/sessions"
 	"github.com/stretchr/testify/assert"
-	
+
 	"flamingo.me/flamingo/v3/framework/flamingo"
 )
 
 func TestRouter(t *testing.T) {
 	router := &Router{
 		eventRouter:    new(flamingo.DefaultEventRouter),
-		routesProvider: func() []RoutesModule { return nil },
 		filterProvider: func() []Filter { return nil },
+		routesProvider: func() []RoutesModule { return nil },
+		logger:         flamingo.NullLogger{},
 	}
 
 	h := router.Handler()
@@ -156,6 +157,7 @@ func TestRouterTestify(t *testing.T) {
 		eventRouter:    new(flamingo.DefaultEventRouter),
 		routesProvider: func() []RoutesModule { return nil },
 		filterProvider: func() []Filter { return nil },
+		logger:         flamingo.NullLogger{},
 	}
 
 	h := router.Handler()


### PR DESCRIPTION
Observations:
* Accesstoken seems to be empty in some cases (e.g. error in oauth2 provider)

Other Issues:
* The openid token is saved only once in callback controller in the session
* services that need to get the accesstoken do this normaly by:

```
1 auth = authmanager.Auth()
2 token = auth.TokenSource.Token()
3 token.AccessToken
```
1 gets tokensource from saved oauth2 token in session
   - how does that work since a reference is supposed to be saved in session:
         - after writing the session?
         - in cluster setup?
         (imho pointer should never be saved in session)

2  this call will renew the token if it is expired - but never saved back to session

Solution:
* Whenever a consumer calls  authmanager.Auth() - he should get is based on an eventually renewed "new" Token
* write no pointer in session
