### PR TITLE
framework/cmd, framework/config: fix flag usage

### DIFF
--- a/app.go
+++ b/app.go
@@ -139,6 +139,7 @@ func App(modules []dingo.Module, options ...option) {
 
 	root.Modules = append([]dingo.Module{
 		new(framework.InitModule),
+		new(config.Flags),
 		new(zap.Module),
 		new(cmd.Module),
 	}, root.Modules...)

--- a/framework/cmd/Readme.md
+++ b/framework/cmd/Readme.md
@@ -72,3 +72,18 @@ Flags:
 
 Use "main [command] --help" for more information about a command.
 ```
+
+## Adding persistent flags to the root command
+
+You can add persistent [flags](https://github.com/spf13/cobra#flags) to Flamingo's root command by multi-binding a 
+[`FlagSet`](https://godoc.org/github.com/spf13/pflag#FlagSet) to `*pflag.FlagSet`:
+
+```go
+// Configure DI
+func (m *Module) Configure(injector *dingo.Injector) {
+	injector.BindMulti((*pflag.FlagSet)(nil)).ToInstance(someFlagSet)
+}
+
+```
+
+

--- a/framework/config/module.go
+++ b/framework/config/module.go
@@ -2,25 +2,39 @@ package config
 
 import (
 	"flamingo.me/dingo"
+	"github.com/spf13/pflag"
 )
 
-// Module defines a dingo module which automatically binds provided config.
-// Normaly this module is not included in your flamingo projects bootstrap.
-//
-// Its can be useful for testing dingo.Module that require certain configuration to be set before. E.g.:
-//
-// cfgModule := &config.Module{
-//		Map: config.Map{
-//			"redirects.useInRouter":       true,
-//			"redirects.useInPrefixRouter": true,
-//		},
-//	}
-//
-//	if err := dingo.TryModule(cfgModule, module); err != nil {
-//		t.Error(err)
-//	}
-type Module struct {
-	Map
+type (
+	// Module defines a dingo module which automatically binds provided config.
+	// Normaly this module is not included in your flamingo projects bootstrap.
+	//
+	// Its can be useful for testing dingo.Module that require certain configuration to be set before. E.g.:
+	//
+	// cfgModule := &config.Module{
+	// 		Map: config.Map{
+	// 			"redirects.useInRouter":       true,
+	// 			"redirects.useInPrefixRouter": true,
+	// 		},
+	// 	}
+	//
+	// 	if err := dingo.TryModule(cfgModule, module); err != nil {
+	// 		t.Error(err)
+	// 	}
+	Module struct {
+		Map
+	}
+
+	// Flags handles the persistent flags provided by the config module
+	Flags struct{}
+)
+
+var flagSet *pflag.FlagSet
+
+func init() {
+	flagSet = pflag.NewFlagSet("flamingo.config", pflag.ContinueOnError)
+	flagSet.BoolVar(&debugLog, "flamingo-config-log", false, "enable flamingo config loader logging")
+	flagSet.StringArrayVar(&additionalConfig, "flamingo-config", []string{}, "add multiple flamingo config additions")
 }
 
 // Configure the Module
@@ -31,4 +45,9 @@ func (m *Module) Configure(injector *dingo.Injector) {
 		}
 		injector.Bind(v).AnnotatedWith("config:" + k).ToInstance(v)
 	}
+}
+
+// Configure DI
+func (f *Flags) Configure(injector *dingo.Injector) {
+	injector.BindMulti((*pflag.FlagSet)(nil)).ToInstance(flagSet)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module flamingo.me/flamingo/v3
 
 require (
-	flamingo.me/dingo v0.1.3
+	flamingo.me/dingo v0.1.5
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/boj/redistore v0.0.0-20180917114910-cd5dcc76aeff
 	github.com/coreos/go-oidc v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 flamingo.me/dingo v0.1.3 h1:C9O3PHpBONfA8p7KI7VX7rGFGyDeTgaJT1EExcAscaw=
 flamingo.me/dingo v0.1.3/go.mod h1:9jDIxhkRLEW9I8axzJb0S/kJ0xv3U8gPxY92uEIHEcE=
+flamingo.me/dingo v0.1.5 h1:nvhmtoSE8ihA+q5qHgh6WXrmLS5QX8jdCDwydyIrwh8=
+flamingo.me/dingo v0.1.5/go.mod h1:jLnqSPkxqE113eKreQ4uBx1fnwluGuaK3rjRi9041wU=
 git.apache.org/thrift.git v0.12.0 h1:CMxsZlAmxKs+VAZMlDDL0wXciMblJcutQbEe3A9CYUM=
 git.apache.org/thrift.git v0.12.0 h1:CMxsZlAmxKs+VAZMlDDL0wXciMblJcutQbEe3A9CYUM=
 git.apache.org/thrift.git v0.12.0/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=


### PR DESCRIPTION
persistent flags for the root command can now be registered via dingo.
The broken flags of the config module are fixed by using this.