### PR TITLE
core/locale: Add support for various number types in price format template function

### DIFF
--- a/core/locale/Readme.md
+++ b/core/locale/Readme.md
@@ -44,17 +44,17 @@ By providing different configurations for the different configuration areas (see
   __("key")
   
   # Display the label and pass a default that is used if the key is not existend in a labelfile
-	__("key").SetDefaultLabel("default")
+	__("key").setDefaultLabel("default")
 	
 	# Display the label with dynamic values replaces:
-	__("key").SetDefaultLabel("Hello Mr {{.UserName}}").SetTranslationArguments({UserName: "Max"})
+	__("key").setDefaultLabel("Hello Mr {{.UserName}}").setTranslationArguments({UserName: "Max"})
 	
 	# Support the usage of plural labels idepending on a given count:
-	__("unread_mails").SetCount(5)
+	__("unread_mails").setCount(5)
 	
 	
 	# Force the usage of another local by passing languange code as 5th paramater:
-	__("switch_to_german").SetLocale("de-DE")
+	__("switch_to_german").setLocale("de-DE")
 	
 ```
 
@@ -114,8 +114,10 @@ Other functions are `formalToLocalDate()` or `formatTime()` etc..
 ### Formatting of prices:
 
 ```pug
-priceFormat(90,"GBP")
-priceFormatLong(90,"GBP","british pound")
+priceFormat(90.25,"£")
+// £ 90.25
+priceFormatLong(42049.99,"$","USD")
+// $ 42,049.99 USD
 ```
 
 ### Formatting of numbers:

--- a/core/locale/interfaces/templatefunctions/label.go
+++ b/core/locale/interfaces/templatefunctions/label.go
@@ -24,17 +24,12 @@ func (tf *Label) Inject(labelService *application.LabelService, logger flamingo.
 }
 
 // Func template function factory
-// todo fix
 func (tf *Label) Func(context.Context) interface{} {
 
-	// Usage:  __("key")
-	// __("key","default")
-	// __("key","Hello Mr {{.userName}}",{UserName: "Max"})
-	// Force other than configured locale: __("switch_to_german","",{},"de-DE")
 	return func(key string, params ...interface{}) *domain.Label {
 
 		if len(params) > 0 {
-			tf.logger.Warn("Depricated unsupported paramaters given! Use the Setters provided by the returned Label " + key)
+			tf.logger.Warn("Deprecated unsupported parameters given! Use the Setters provided by the returned Label " + key)
 
 		}
 		return tf.labelService.NewLabel(key)

--- a/core/locale/interfaces/templatefunctions/priceFormat.go
+++ b/core/locale/interfaces/templatefunctions/priceFormat.go
@@ -2,6 +2,7 @@ package templatefunctions
 
 import (
 	"context"
+	"math/big"
 
 	"flamingo.me/flamingo/v3/core/locale/application"
 	"flamingo.me/flamingo/v3/framework/config"
@@ -10,7 +11,7 @@ import (
 
 // PriceFormatFunc for formatting prices
 type PriceFormatFunc struct {
-	config             config.Map
+	config       config.Map
 	labelService *application.LabelService
 }
 
@@ -22,10 +23,11 @@ func (pff *PriceFormatFunc) Inject(labelService *application.LabelService, confi
 	pff.config = config.Config
 }
 
-// Func as implementation of debug method
-// todo fix
+// Func formats the value and adds currency sign/symbol
+// example output could be: $ 21,500.99
+// (supported value types : int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, *big.Rat, *big.Float)
 func (pff *PriceFormatFunc) Func(context.Context) interface{} {
-	return func(value float64, currency string) string {
+	return func(value interface{}, currency string) string {
 		currency = pff.labelService.NewLabel(currency).String()
 		ac := accounting.Accounting{
 			Symbol:    currency,
@@ -46,6 +48,11 @@ func (pff *PriceFormatFunc) Func(context.Context) interface{} {
 		format, ok := pff.config["format"].(string)
 		if ok {
 			ac.Format = format
+		}
+
+		valueBigFloat, ok := value.(*big.Float)
+		if ok {
+			return ac.FormatMoneyBigFloat(valueBigFloat)
 		}
 
 		return ac.FormatMoney(value)

--- a/core/locale/interfaces/templatefunctions/priceFormat.go
+++ b/core/locale/interfaces/templatefunctions/priceFormat.go
@@ -2,7 +2,6 @@ package templatefunctions
 
 import (
 	"context"
-	"math/big"
 
 	"flamingo.me/flamingo/v3/core/locale/application"
 	"flamingo.me/flamingo/v3/framework/config"
@@ -25,9 +24,8 @@ func (pff *PriceFormatFunc) Inject(labelService *application.LabelService, confi
 
 // Func formats the value and adds currency sign/symbol
 // example output could be: $ 21,500.99
-// (supported value types : int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, *big.Rat, *big.Float)
 func (pff *PriceFormatFunc) Func(context.Context) interface{} {
-	return func(value interface{}, currency string) string {
+	return func(value float64, currency string) string {
 		currency = pff.labelService.NewLabel(currency).String()
 		ac := accounting.Accounting{
 			Symbol:    currency,
@@ -48,11 +46,6 @@ func (pff *PriceFormatFunc) Func(context.Context) interface{} {
 		format, ok := pff.config["format"].(string)
 		if ok {
 			ac.Format = format
-		}
-
-		valueBigFloat, ok := value.(*big.Float)
-		if ok {
-			return ac.FormatMoneyBigFloat(valueBigFloat)
 		}
 
 		return ac.FormatMoney(value)

--- a/core/locale/interfaces/templatefunctions/priceFormatLong.go
+++ b/core/locale/interfaces/templatefunctions/priceFormatLong.go
@@ -8,11 +8,11 @@ import (
 	"flamingo.me/flamingo/v3/framework/config"
 )
 
-// PriceFormatLongFunc for formatting prices
+// PriceFormatLongFunc for formatting prices with additional currency code/label
 type PriceFormatLongFunc struct {
-	config             config.Map
+	config       config.Map
 	labelService *application.LabelService
-	priceFormat        *PriceFormatFunc
+	priceFormat  *PriceFormatFunc
 }
 
 // Inject dependencies
@@ -28,7 +28,9 @@ func (pff *PriceFormatLongFunc) Inject(
 	pff.priceFormat = formatFunc
 }
 
-// Func as implementation of debug method
+// Func formats the value, adds currency sign/symbol and add an additional currency code/label
+// example output could be: $ 21,500.99 USD
+// (supported value types : int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, *big.Rat, *big.Float)
 func (pff *PriceFormatLongFunc) Func(ctx context.Context) interface{} {
 	return func(value interface{}, currency string, currencyLabel string) string {
 		priceFunc := pff.priceFormat.Func(ctx).(func(value interface{}, currency string) string)

--- a/core/locale/interfaces/templatefunctions/priceFormatLong.go
+++ b/core/locale/interfaces/templatefunctions/priceFormatLong.go
@@ -30,10 +30,9 @@ func (pff *PriceFormatLongFunc) Inject(
 
 // Func formats the value, adds currency sign/symbol and add an additional currency code/label
 // example output could be: $ 21,500.99 USD
-// (supported value types : int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, *big.Rat, *big.Float)
 func (pff *PriceFormatLongFunc) Func(ctx context.Context) interface{} {
-	return func(value interface{}, currency string, currencyLabel string) string {
-		priceFunc := pff.priceFormat.Func(ctx).(func(value interface{}, currency string) string)
+	return func(value float64, currency string, currencyLabel string) string {
+		priceFunc := pff.priceFormat.Func(ctx).(func(value float64, currency string) string)
 		price := priceFunc(value, currency)
 		currencyLabel = pff.labelService.NewLabel(currencyLabel).String()
 		format, ok := pff.config["formatLong"].(string)

--- a/core/locale/interfaces/templatefunctions/priceFormatLong_test.go
+++ b/core/locale/interfaces/templatefunctions/priceFormatLong_test.go
@@ -20,7 +20,7 @@ func TestPriceFormatLongFunc_Func(t *testing.T) {
 		labelService *application.LabelService
 	}
 	type args struct {
-		value         interface{}
+		value         float64
 		currency      string
 		currencyLabel string
 	}
@@ -31,7 +31,7 @@ func TestPriceFormatLongFunc_Func(t *testing.T) {
 		want   interface{}
 	}{
 		{
-			name: "float64",
+			name: "$ USD",
 			fields: fields{
 				config: config.Map{
 					"decimal":    ".",
@@ -43,7 +43,7 @@ func TestPriceFormatLongFunc_Func(t *testing.T) {
 				labelService: labelService,
 			},
 			args: args{
-				value:         float64(21500.99),
+				value:         21500.99,
 				currency:      "$",
 				currencyLabel: "USD",
 			},
@@ -62,7 +62,7 @@ func TestPriceFormatLongFunc_Func(t *testing.T) {
 				Config config.Map `inject:"config:locale.accounting"`
 			}{tt.fields.config})
 
-			templateFunc := priceFormatLongFunc.Func(context.Background()).(func(value interface{}, currency string, currencyLabel string) string)
+			templateFunc := priceFormatLongFunc.Func(context.Background()).(func(value float64, currency string, currencyLabel string) string)
 
 			if got := templateFunc(tt.args.value, tt.args.currency, tt.args.currencyLabel); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NumberFormatFunc.Func() = %v, want %v", got, tt.want)

--- a/core/locale/interfaces/templatefunctions/priceFormatLong_test.go
+++ b/core/locale/interfaces/templatefunctions/priceFormatLong_test.go
@@ -1,0 +1,72 @@
+package templatefunctions_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"flamingo.me/flamingo/v3/core/locale/application"
+	"flamingo.me/flamingo/v3/core/locale/interfaces/templatefunctions"
+	"flamingo.me/flamingo/v3/framework/config"
+)
+
+func TestPriceFormatLongFunc_Func(t *testing.T) {
+	labelService := &application.LabelService{}
+
+	labelService.Inject(FakeLabelProvider, nil)
+
+	type fields struct {
+		config       config.Map `inject:"config:locale.accounting"`
+		labelService *application.LabelService
+	}
+	type args struct {
+		value         interface{}
+		currency      string
+		currencyLabel string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   interface{}
+	}{
+		{
+			name: "float64",
+			fields: fields{
+				config: config.Map{
+					"decimal":    ".",
+					"thousand":   ",",
+					"formatZero": "%s -,-",
+					"format":     "%s %v",
+					"formatLong": "%v %v",
+				},
+				labelService: labelService,
+			},
+			args: args{
+				value:         float64(21500.99),
+				currency:      "$",
+				currencyLabel: "USD",
+			},
+			want: "$ 21,500.99 USD",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			priceFormatFunc := &templatefunctions.PriceFormatFunc{}
+			priceFormatFunc.Inject(tt.fields.labelService, &struct {
+				Config config.Map `inject:"config:locale.accounting"`
+			}{tt.fields.config})
+
+			priceFormatLongFunc := &templatefunctions.PriceFormatLongFunc{}
+			priceFormatLongFunc.Inject(tt.fields.labelService, priceFormatFunc, &struct {
+				Config config.Map `inject:"config:locale.accounting"`
+			}{tt.fields.config})
+
+			templateFunc := priceFormatLongFunc.Func(context.Background()).(func(value interface{}, currency string, currencyLabel string) string)
+
+			if got := templateFunc(tt.args.value, tt.args.currency, tt.args.currencyLabel); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NumberFormatFunc.Func() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/core/locale/interfaces/templatefunctions/priceFormat_test.go
+++ b/core/locale/interfaces/templatefunctions/priceFormat_test.go
@@ -1,0 +1,119 @@
+package templatefunctions_test
+
+import (
+	"context"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"flamingo.me/flamingo/v3/core/locale/application"
+	"flamingo.me/flamingo/v3/core/locale/domain"
+	"flamingo.me/flamingo/v3/core/locale/interfaces/templatefunctions"
+	"flamingo.me/flamingo/v3/framework/config"
+)
+
+type FakeTranslationService struct{}
+
+func (s *FakeTranslationService) Translate(key string, defaultLabel string, localeCode string, count int, translationArguments map[string]interface{}) string {
+	return defaultLabel
+}
+
+func (s *FakeTranslationService) TranslateLabel(label domain.Label) string {
+	return label.GetDefaultLabel()
+}
+
+func FakeLabelProvider() *domain.Label {
+	label := &domain.Label{}
+	label.Inject(new(FakeTranslationService))
+	return label
+}
+
+func TestPriceFormatFunc_Func(t *testing.T) {
+	labelService := &application.LabelService{}
+
+	labelService.Inject(FakeLabelProvider, nil)
+
+	type fields struct {
+		config       config.Map `inject:"config:locale.accounting"`
+		labelService *application.LabelService
+	}
+	type args struct {
+		value    interface{}
+		currency string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   interface{}
+	}{
+		{
+			name: "float64",
+			fields: fields{
+				config: config.Map{
+					"decimal":    ",",
+					"thousand":   ".",
+					"formatZero": "%s -,-",
+					"format":     "%s %v",
+					"formatLong": "%v %v",
+				},
+				labelService: labelService,
+			},
+			args: args{
+				value:    float64(21500.99),
+				currency: "€",
+			},
+			want: "€ 21.500,99",
+		},
+		{
+			name: "int",
+			fields: fields{
+				config: config.Map{
+					"decimal":    ".",
+					"thousand":   ",",
+					"formatZero": "%s -,-",
+					"format":     "%s %v",
+					"formatLong": "%v %v",
+				},
+				labelService: labelService,
+			},
+			args: args{
+				value:    int(55),
+				currency: "$",
+			},
+			want: "$ 55.00",
+		},
+		{
+			name: "big.Float",
+			fields: fields{
+				config: config.Map{
+					"decimal":    ".",
+					"thousand":   ",",
+					"formatZero": "%s -,-",
+					"format":     "%s %v",
+					"formatLong": "%v %v",
+				},
+				labelService: labelService,
+			},
+			args: args{
+				value:    big.NewFloat(21500.99),
+				currency: "¥",
+			},
+			want: "¥ 21,500.99",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nff := &templatefunctions.PriceFormatFunc{}
+			nff.Inject(tt.fields.labelService, &struct {
+				Config config.Map `inject:"config:locale.accounting"`
+			}{tt.fields.config})
+
+			templateFunc := nff.Func(context.Background()).(func(value interface{}, currency string) string)
+
+			if got := templateFunc(tt.args.value, tt.args.currency); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NumberFormatFunc.Func() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/core/locale/interfaces/templatefunctions/priceFormat_test.go
+++ b/core/locale/interfaces/templatefunctions/priceFormat_test.go
@@ -2,7 +2,6 @@ package templatefunctions_test
 
 import (
 	"context"
-	"math/big"
 	"reflect"
 	"testing"
 
@@ -38,7 +37,7 @@ func TestPriceFormatFunc_Func(t *testing.T) {
 		labelService *application.LabelService
 	}
 	type args struct {
-		value    interface{}
+		value    float64
 		currency string
 	}
 	tests := []struct {
@@ -48,7 +47,7 @@ func TestPriceFormatFunc_Func(t *testing.T) {
 		want   interface{}
 	}{
 		{
-			name: "float64",
+			name: "Euro",
 			fields: fields{
 				config: config.Map{
 					"decimal":    ",",
@@ -60,13 +59,13 @@ func TestPriceFormatFunc_Func(t *testing.T) {
 				labelService: labelService,
 			},
 			args: args{
-				value:    float64(21500.99),
+				value:    21500.99,
 				currency: "€",
 			},
 			want: "€ 21.500,99",
 		},
 		{
-			name: "int",
+			name: "Dollar",
 			fields: fields{
 				config: config.Map{
 					"decimal":    ".",
@@ -78,28 +77,10 @@ func TestPriceFormatFunc_Func(t *testing.T) {
 				labelService: labelService,
 			},
 			args: args{
-				value:    int(55),
+				value:    55,
 				currency: "$",
 			},
 			want: "$ 55.00",
-		},
-		{
-			name: "big.Float",
-			fields: fields{
-				config: config.Map{
-					"decimal":    ".",
-					"thousand":   ",",
-					"formatZero": "%s -,-",
-					"format":     "%s %v",
-					"formatLong": "%v %v",
-				},
-				labelService: labelService,
-			},
-			args: args{
-				value:    big.NewFloat(21500.99),
-				currency: "¥",
-			},
-			want: "¥ 21,500.99",
 		},
 	}
 	for _, tt := range tests {
@@ -109,7 +90,7 @@ func TestPriceFormatFunc_Func(t *testing.T) {
 				Config config.Map `inject:"config:locale.accounting"`
 			}{tt.fields.config})
 
-			templateFunc := nff.Func(context.Background()).(func(value interface{}, currency string) string)
+			templateFunc := nff.Func(context.Background()).(func(value float64, currency string) string)
 
 			if got := templateFunc(tt.args.value, tt.args.currency); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NumberFormatFunc.Func() = %v, want %v", got, tt.want)


### PR DESCRIPTION
Price format functions now support all types that the underlying [accounting](https://github.com/leekchan/accounting) module supports.
- Add tests for price related template functions
- Update readme to include better examples