### PR TITLE
web: use session.name config actually for the session name

### DIFF
--- a/framework/web/router.go
+++ b/framework/web/router.go
@@ -56,13 +56,14 @@ const (
 // Inject dependencies
 func (r *Router) Inject(
 	cfg *struct {
-	// base url configuration
-	Scheme       string         `inject:"config:flamingo.router.scheme,optional"`
-	Host         string         `inject:"config:flamingo.router.host,optional"`
-	Path         string         `inject:"config:flamingo.router.path,optional"`
-	External     string         `inject:"config:flamingo.router.external,optional"`
-	SessionStore sessions.Store `inject:",optional"`
-},
+		// base url configuration
+		Scheme       string         `inject:"config:flamingo.router.scheme,optional"`
+		Host         string         `inject:"config:flamingo.router.host,optional"`
+		Path         string         `inject:"config:flamingo.router.path,optional"`
+		External     string         `inject:"config:flamingo.router.external,optional"`
+		SessionStore sessions.Store `inject:",optional"`
+		SessionName  string         `inject:"config:session.name,optional"`
+	},
 	eventRouter flamingo.EventRouter,
 	filterProvider filterProvider,
 	routesProvider routesProvider,
@@ -88,6 +89,9 @@ func (r *Router) Inject(
 	r.configArea = configArea
 	r.sessionStore = cfg.SessionStore
 	r.sessionName = "flamingo"
+	if cfg.SessionName != "" {
+		r.sessionName = cfg.SessionName
+	}
 }
 
 // Handler creates and returns new instance of http.Handler interface
@@ -121,7 +125,7 @@ func (r *Router) Handler() http.Handler {
 		routerRegistry: r.routerRegistry,
 		filter:         r.filterProvider(),
 		eventRouter:    r.eventRouter,
-		logger:         r.logger.WithField(flamingo.LogKeyModule,"web").WithField(flamingo.LogKeyCategory,"handler"),
+		logger:         r.logger.WithField(flamingo.LogKeyModule, "web").WithField(flamingo.LogKeyCategory, "handler"),
 		sessionStore:   r.sessionStore,
 		sessionName:    r.sessionName,
 		prefix:         strings.TrimRight(r.base.Path, "/"),

--- a/framework/web/router_test.go
+++ b/framework/web/router_test.go
@@ -196,11 +196,13 @@ func TestRouterRelativeAndAbsolute(t *testing.T) {
 			Path         string         `inject:"config:flamingo.router.path,optional"`
 			External     string         `inject:"config:flamingo.router.external,optional"`
 			SessionStore sessions.Store `inject:",optional"`
+			SessionName  string         `inject:"config:session.name,optional"`
 		}{
-			Scheme:   scheme,
-			Host:     host,
-			Path:     path,
-			External: external,
+			Scheme:      scheme,
+			Host:        host,
+			Path:        path,
+			External:    external,
+			SessionName: "test",
 		}, new(flamingo.DefaultEventRouter), func() []Filter { return nil }, func() []RoutesModule { return nil }, flamingo.NullLogger{}, nil)
 
 		registry.HandleGet("test", func(context.Context, *Request) Result {


### PR DESCRIPTION
The usage of this config value has been dropped accidentally
during v3 refactoring work