### PR TITLE
gotemplate: more convenient usage of template functions

### DIFF
--- a/core/gotemplate/engine.go
+++ b/core/gotemplate/engine.go
@@ -37,27 +37,10 @@ type (
 		Relative(name string, params map[string]string) (*url.URL, error)
 		Data(ctx context.Context, handler string, params map[interface{}]interface{}) interface{}
 	}
-
-	// urlFunc allows templates to access the routers `URL` helper method
-	urlFunc struct {
-		router urlRouter
-	}
-
-	// getFunc allows templates to access the router's `get` method
-	dataFunc struct {
-		router urlRouter
-	}
-
-	getFunc struct {
-		router urlRouter
-	}
 )
 
 var (
-	_    flamingo.TemplateFunc = new(urlFunc)
-	_    flamingo.TemplateFunc = new(getFunc)
-	_    flamingo.TemplateFunc = new(dataFunc)
-	lock                       = &sync.Mutex{}
+	lock = &sync.Mutex{}
 )
 
 // Inject engine dependencies
@@ -230,59 +213,4 @@ func (e *engine) parseSiteTemplateDirectory(layoutTemplate *template.Template, d
 	}
 
 	return nil
-}
-
-func (g *getFunc) Inject(router urlRouter) *getFunc {
-	g.router = router
-	return g
-}
-
-// TemplateFunc as implementation of get method
-func (g *getFunc) Func(ctx context.Context) interface{} {
-	return func(what string, params ...map[string]interface{}) interface{} {
-		var p = make(map[interface{}]interface{})
-		if len(params) == 1 {
-			for k, v := range params[0] {
-				p[k] = fmt.Sprint(v)
-			}
-		}
-		return g.router.Data(ctx, what, p)
-	}
-}
-
-func (d *dataFunc) Inject(router urlRouter) *dataFunc {
-	d.router = router
-	return d
-}
-
-// TemplateFunc as implementation of get method
-func (d *dataFunc) Func(ctx context.Context) interface{} {
-	return func(what string, params ...map[string]interface{}) interface{} {
-		var p = make(map[interface{}]interface{})
-		if len(params) == 1 {
-			for k, v := range params[0] {
-				p[k] = fmt.Sprint(v)
-			}
-		}
-		return d.router.Data(ctx, what, p)
-	}
-}
-
-func (u *urlFunc) Inject(router urlRouter) *urlFunc {
-	u.router = router
-	return u
-}
-
-// TemplateFunc as implementation of url method
-func (u *urlFunc) Func(context.Context) interface{} {
-	return func(where string, params ...map[string]interface{}) template.URL {
-		var p = make(map[string]string)
-		if len(params) == 1 {
-			for k, v := range params[0] {
-				p[k] = fmt.Sprint(v)
-			}
-		}
-		url, _ := u.router.Relative(where, p)
-		return template.URL(url.String())
-	}
 }

--- a/core/gotemplate/module.go
+++ b/core/gotemplate/module.go
@@ -2,6 +2,7 @@ package gotemplate
 
 import (
 	"flamingo.me/dingo"
+
 	"flamingo.me/flamingo/v3/framework/config"
 	"flamingo.me/flamingo/v3/framework/flamingo"
 	"flamingo.me/flamingo/v3/framework/web"
@@ -18,6 +19,8 @@ func (m *Module) Configure(injector *dingo.Injector) {
 	flamingo.BindTemplateFunc(injector, "url", new(urlFunc))
 	flamingo.BindTemplateFunc(injector, "get", new(getFunc))
 	flamingo.BindTemplateFunc(injector, "data", new(dataFunc))
+	flamingo.BindTemplateFunc(injector, "plainHtml", new(plainHTMLFunc))
+	flamingo.BindTemplateFunc(injector, "plainJs", new(plainJSFunc))
 }
 
 // DefaultConfig for gotemplate module

--- a/core/gotemplate/templatefunctions.go
+++ b/core/gotemplate/templatefunctions.go
@@ -1,0 +1,101 @@
+package gotemplate
+
+import (
+	"context"
+	"html/template"
+
+	"flamingo.me/flamingo/v3/framework/flamingo"
+)
+
+type (
+	// urlFunc allows templates to access the routers `URL` helper method
+	urlFunc struct {
+		router urlRouter
+	}
+
+	dataFunc struct {
+		router urlRouter
+	}
+
+	// getFunc allows templates to access the router's `get` method
+	getFunc struct {
+		router urlRouter
+	}
+
+	// plainHTMLFunc returns the given string as plain template HTML
+	plainHTMLFunc struct{}
+
+	// plainJSFunc returns the given string as plain template JS
+	plainJSFunc struct{}
+)
+
+var (
+	_ flamingo.TemplateFunc = new(urlFunc)
+	_ flamingo.TemplateFunc = new(getFunc)
+	_ flamingo.TemplateFunc = new(dataFunc)
+	_ flamingo.TemplateFunc = new(plainHTMLFunc)
+	_ flamingo.TemplateFunc = new(plainJSFunc)
+)
+
+func (g *getFunc) Inject(router urlRouter) *getFunc {
+	g.router = router
+	return g
+}
+
+// TemplateFunc as implementation of get method
+func (g *getFunc) Func(ctx context.Context) interface{} {
+	return func(what string, params ...string) interface{} {
+		var p = make(map[interface{}]interface{})
+		for i := 0; i < len(params); i += 2 {
+			p[params[i]] = params[i+1]
+		}
+		return g.router.Data(ctx, what, p)
+	}
+}
+
+func (d *dataFunc) Inject(router urlRouter) *dataFunc {
+	d.router = router
+	return d
+}
+
+// Func as implementation of get method
+func (d *dataFunc) Func(ctx context.Context) interface{} {
+	return func(what string, params ...string) interface{} {
+		var p = make(map[interface{}]interface{})
+		for i := 0; i < len(params); i += 2 {
+			p[params[i]] = params[i+1]
+		}
+		return d.router.Data(ctx, what, p)
+	}
+}
+
+func (u *urlFunc) Inject(router urlRouter) *urlFunc {
+	u.router = router
+	return u
+}
+
+// Func as implementation of url method
+func (u *urlFunc) Func(context.Context) interface{} {
+	return func(where string, params ...string) template.URL {
+		var p = make(map[string]string)
+		for i := 0; i < len(params); i += 2 {
+			p[params[i]] = params[i+1]
+		}
+		url, _ := u.router.Relative(where, p)
+		return template.URL(url.String())
+	}
+}
+
+// Func returns the given string as plain template HTML
+func (s *plainHTMLFunc) Func(_ context.Context) interface{} {
+	return func(in string) template.HTML {
+		return template.HTML(in)
+	}
+}
+
+// Func returns the given string as plain template JS
+func (s *plainJSFunc) Func(_ context.Context) interface{} {
+	return func(in string) template.JS {
+		return template.JS(in)
+	}
+}


### PR DESCRIPTION
It's not suitable to enter maps form a gotemplate file, so the functions
take the map as variadic arguments alternating between key and value.

On top there was no possibility to print unescaped HTML and JS which can
now be done with the plainHTML and plainJS template functions.