### PR TITLE
Systemendpoint should be used individually

### DIFF
--- a/framework/systemendpoint/application/server.go
+++ b/framework/systemendpoint/application/server.go
@@ -43,6 +43,7 @@ func (s *SystemServer) Notify(_ context.Context, e flamingo.Event) {
 	}
 }
 
+//Start - starts the systemendpoint in a sperate go routine
 func (s *SystemServer) Start() {
 	s.logger.Info("systemendpoint: Start at ", s.serviceAddress)
 	serveMux := http.NewServeMux()

--- a/framework/systemendpoint/application/server.go
+++ b/framework/systemendpoint/application/server.go
@@ -31,18 +31,20 @@ func (s *SystemServer) Inject(
 	s.serviceAddress = config.ServiceAddress
 }
 
-// Notify handles required actions on startup and shutdown
+// Notify handles required actions on Start and shutdown
 func (s *SystemServer) Notify(_ context.Context, e flamingo.Event) {
 	switch e.(type) {
 	case *flamingo.ServerStartEvent:
-		s.startup()
+		s.Start()
 	case *flamingo.ServerShutdownEvent:
+		s.shutdown()
+	case *flamingo.ShutdownEvent:
 		s.shutdown()
 	}
 }
 
-func (s *SystemServer) startup() {
-	s.logger.Info("systemendpoint: startup at ", s.serviceAddress)
+func (s *SystemServer) Start() {
+	s.logger.Info("systemendpoint: Start at ", s.serviceAddress)
 	serveMux := http.NewServeMux()
 	for route, handler := range s.handlerProvider() {
 		if handler != nil {


### PR DESCRIPTION
Currently Systemendpoint starts with "serve" command.

But there are cases where one want an own command but still run the Systemendpoint.

