### PR TITLE
oauth: Fix potential nil pointer if context has no request

### DIFF
--- a/core/oauth/application/userservice.go
+++ b/core/oauth/application/userservice.go
@@ -46,8 +46,7 @@ func (us *UserService) getUser(c context.Context, session *web.Session) *domain.
 		return domain.Guest
 	}
 
-	r := web.RequestFromContext(c)
-	user, err := us.mappingService.UserFromIDToken(id, r.Session())
+	user, err := us.mappingService.UserFromIDToken(id, session)
 	if user == nil || err != nil {
 		return domain.Guest
 	}


### PR DESCRIPTION
Strangely all user service methods have the session as a parameter but the getUser() method still tries to get the session from the context request. This leads to a potential nil pointer access if the context does not contain a request.