### PR TITLE
oauth: support multiple claim keys in mapping config

### DIFF
--- a/core/oauth/Readme.md
+++ b/core/oauth/Readme.md
@@ -64,11 +64,13 @@ oauth:
     city: someCity
     dateOfBirth: someDateOfBirth
     country: someCountry
-    groups: someGroups
+    groups: groupfield1;groupfield2
     customFields:
     - someField1
     - someField2
 ```
+
+As you see above the mapping allows to specify multiple keys in the claim. So `groups: groupfield1;groupfield2` will map the group property of the user object from the claim `groupfield1` and if that is not present it will use `groupfield2`. 
 
 # Use fakes
 

--- a/core/oauth/domain/mapping.go
+++ b/core/oauth/domain/mapping.go
@@ -125,9 +125,9 @@ func (ums *UserMappingService) mapCustomFields(mapping []string, claims map[stri
 }
 
 func (ums *UserMappingService) mapField(mappedFieldName string, claims map[string]interface{}) string {
-	claimKeys := strings.Split(mappedFieldName,";")
-	for _,key := range claimKeys {
-		if value, ok := claims[key].(string); ok {
+	claimKeys := strings.Split(mappedFieldName, ";")
+	for _, key := range claimKeys {
+		if value, ok := claims[strings.TrimSpace(key)].(string); ok {
 			return value
 		}
 	}

--- a/core/oauth/domain/mapping.go
+++ b/core/oauth/domain/mapping.go
@@ -125,11 +125,13 @@ func (ums *UserMappingService) mapCustomFields(mapping []string, claims map[stri
 }
 
 func (ums *UserMappingService) mapField(mappedFieldName string, claims map[string]interface{}) string {
-	value, ok := claims[mappedFieldName].(string)
-	if !ok {
-		return ""
+	claimKeys := strings.Split(mappedFieldName,";")
+	for _,key := range claimKeys {
+		if value, ok := claims[key].(string); ok {
+			return value
+		}
 	}
-	return value
+	return ""
 }
 
 func (ums *UserMappingService) mapSliceField(mappedFieldName string, claims map[string]interface{}) []string {

--- a/core/oauth/domain/mapping_test.go
+++ b/core/oauth/domain/mapping_test.go
@@ -130,7 +130,7 @@ func (t *UserMappingServiceTestSuite) TestMapToUser_AllDifferent() {
 		"someDateOfBirth": "01.01.2000",
 		"someCountry":     "Mars",
 		"whatever":        "value",
-		"userType":        "RU",
+		"customer_groups":        "RU",
 	}
 
 	t.mappingService.idTokenMapping = config.Map{
@@ -146,7 +146,7 @@ func (t *UserMappingServiceTestSuite) TestMapToUser_AllDifferent() {
 		"dateOfBirth":  "someDateOfBirth",
 		"country":      "someCountry",
 		"customFields": config.Slice{"whatever"},
-		"groups":       "userType",
+		"groups":       "userType;customer_groups",
 	}
 
 	t.Equal(&User{


### PR DESCRIPTION
There are cases where properties need to be mapped from different claim keys.
This change propose to configure multiple fields with ";" seperated