### PR TITLE
locale: add price service for formatting

### DIFF
--- a/core/locale/Readme.md
+++ b/core/locale/Readme.md
@@ -17,11 +17,17 @@ locale:
   translationFiles:                                # or a list of label file locations
   - translations/merged/en-gb.all.yaml
   - translations/translated/en-gb.adjusted.yaml
-  accounting:                                      # configure display of prices
-    thousand: ','
-    decimal: '.'
-    formatZero: '%s -.-'
-    format: "%v %s"
+  accounting:
+    default:                                    # configure display of prices
+        thousand: ','
+        decimal: '.'
+        formatZero: '%s -.-'
+        format: "%v %s"
+    GBP:                                        # configure display of prices in currency GBP
+        thousand: ','
+        decimal: '.'
+        formatZero: '%s -.-'
+        format: "%v %s"
   numbers:                                         # configure display of numbers
     thousand: ','
     decimal: '.'

--- a/core/locale/application/priceService.go
+++ b/core/locale/application/priceService.go
@@ -1,0 +1,63 @@
+package application
+
+import (
+	"flamingo.me/flamingo/v3/framework/config"
+	"github.com/leekchan/accounting"
+)
+
+// PriceService for formatting prices
+type PriceService struct {
+	config       config.Map
+	labelService *LabelService
+}
+
+// Inject dependencies
+func (s *PriceService) Inject(labelService *LabelService, config *struct {
+	Config config.Map `inject:"config:locale.accounting"`
+}) {
+	s.labelService = labelService
+	s.config = config.Config
+}
+
+// GetConfigForCurrency get configuration for currency
+func (s *PriceService) getConfigForCurrency(currency string) config.Map {
+	if configForCurrency, ok := s.config[currency]; ok {
+		return configForCurrency.(config.Map)
+	}
+
+	if defaultConfig, ok := s.config["default"].(config.Map); ok {
+		return defaultConfig
+	}
+
+	return s.config
+}
+
+// FormatPrice by price
+func (s *PriceService) FormatPrice(value float64, currency string) string {
+	currency = s.labelService.NewLabel(currency).String()
+
+	configForCurrency := s.getConfigForCurrency(currency)
+
+	ac := accounting.Accounting{
+		Symbol:    currency,
+		Precision: 2,
+	}
+	decimal, ok := configForCurrency["decimal"].(string)
+	if ok {
+		ac.Decimal = decimal
+	}
+	thousand, ok := configForCurrency["thousand"].(string)
+	if ok {
+		ac.Thousand = thousand
+	}
+	formatZero, ok := configForCurrency["formatZero"].(string)
+	if ok {
+		ac.FormatZero = formatZero
+	}
+	format, ok := configForCurrency["format"].(string)
+	if ok {
+		ac.Format = format
+	}
+
+	return ac.FormatMoney(value)
+}

--- a/core/locale/interfaces/templatefunctions/priceFormat.go
+++ b/core/locale/interfaces/templatefunctions/priceFormat.go
@@ -5,49 +5,23 @@ import (
 
 	"flamingo.me/flamingo/v3/core/locale/application"
 	"flamingo.me/flamingo/v3/framework/config"
-	"github.com/leekchan/accounting"
 )
 
 // PriceFormatFunc for formatting prices
 type PriceFormatFunc struct {
 	config       config.Map
-	labelService *application.LabelService
+	priceService *application.PriceService
 }
 
 // Inject dependencies
-func (pff *PriceFormatFunc) Inject(labelService *application.LabelService, config *struct {
-	Config config.Map `inject:"config:locale.accounting"`
-}) {
-	pff.labelService = labelService
-	pff.config = config.Config
+func (pff *PriceFormatFunc) Inject(priceService *application.PriceService) {
+	pff.priceService = priceService
 }
 
 // Func formats the value and adds currency sign/symbol
 // example output could be: $ 21,500.99
 func (pff *PriceFormatFunc) Func(context.Context) interface{} {
 	return func(value float64, currency string) string {
-		currency = pff.labelService.NewLabel(currency).String()
-		ac := accounting.Accounting{
-			Symbol:    currency,
-			Precision: 2,
-		}
-		decimal, ok := pff.config["decimal"].(string)
-		if ok {
-			ac.Decimal = decimal
-		}
-		thousand, ok := pff.config["thousand"].(string)
-		if ok {
-			ac.Thousand = thousand
-		}
-		formatZero, ok := pff.config["formatZero"].(string)
-		if ok {
-			ac.FormatZero = formatZero
-		}
-		format, ok := pff.config["format"].(string)
-		if ok {
-			ac.Format = format
-		}
-
-		return ac.FormatMoney(value)
+		return pff.priceService.FormatPrice(value, currency)
 	}
 }

--- a/core/locale/interfaces/templatefunctions/priceFormatLong_test.go
+++ b/core/locale/interfaces/templatefunctions/priceFormatLong_test.go
@@ -52,10 +52,14 @@ func TestPriceFormatLongFunc_Func(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			priceFormatFunc := &templatefunctions.PriceFormatFunc{}
-			priceFormatFunc.Inject(tt.fields.labelService, &struct {
+
+			priceService := application.PriceService{}
+			priceService.Inject(tt.fields.labelService, &struct {
 				Config config.Map `inject:"config:locale.accounting"`
 			}{tt.fields.config})
+
+			priceFormatFunc := &templatefunctions.PriceFormatFunc{}
+			priceFormatFunc.Inject(&priceService)
 
 			priceFormatLongFunc := &templatefunctions.PriceFormatLongFunc{}
 			priceFormatLongFunc.Inject(tt.fields.labelService, priceFormatFunc, &struct {

--- a/core/locale/interfaces/templatefunctions/priceFormat_test.go
+++ b/core/locale/interfaces/templatefunctions/priceFormat_test.go
@@ -86,9 +86,11 @@ func TestPriceFormatFunc_Func(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			nff := &templatefunctions.PriceFormatFunc{}
-			nff.Inject(tt.fields.labelService, &struct {
+			priceService := application.PriceService{}
+			priceService.Inject(tt.fields.labelService, &struct {
 				Config config.Map `inject:"config:locale.accounting"`
 			}{tt.fields.config})
+			nff.Inject(&priceService)
 
 			templateFunc := nff.Func(context.Background()).(func(value float64, currency string) string)
 

--- a/core/locale/module.go
+++ b/core/locale/module.go
@@ -34,15 +34,17 @@ func (m *Module) DefaultConfig() config.Map {
 		"locale": config.Map{
 			"locale": "en-US",
 			"accounting": config.Map{
-				"decimal":    ",",
-				"thousand":   ".",
-				"formatZero": "%s -,-",
-				"format":     "%s %v",
-				"formatLong": "%v %v",
+				"default": config.Map{
+					"decimal":    ".",
+					"thousand":   ",",
+					"formatZero": "%s 0.00",
+					"format":     "%s %v",
+					"formatLong": "%v %v",
+				},
 			},
 			"numbers": config.Map{
-				"decimal":   ",",
-				"thousand":  ".",
+				"decimal":   ".",
+				"thousand":  ",",
 				"precision": float64(2),
 			},
 			"date": config.Map{


### PR DESCRIPTION
flamingo_commerce introduced a priceService to format prices and allows to configure formatting per currency.
This should move to locale package.

(later flamingo_commerce can use this service instead of own)