### PR TITLE
Check potential external URL for relative URL structure (no host in URL)

### DIFF
--- a/framework/web/templatefunctions.go
+++ b/framework/web/templatefunctions.go
@@ -90,7 +90,7 @@ func (c *IsExternalURL) Func(ctx context.Context) interface{} {
 	return func(urlStr string) bool {
 		if u, err := url.Parse(urlStr); err == nil {
 			au, _ := c.router.Absolute(RequestFromContext(ctx), "", nil)
-			return au.Host != u.Host
+			return u.Host != "" && au.Host != u.Host
 		}
 
 		return false


### PR DESCRIPTION
When checking URLs like "/en/category/mycategory" the external URL checker returns true although it is a relative URL meaning it is not external.