### PR TITLE
config: make tests more robust

### DIFF
--- a/framework/config/loader_test.go
+++ b/framework/config/loader_test.go
@@ -54,6 +54,7 @@ func TestLoad(t *testing.T) {
 		root := new(Area)
 		require.NoError(t, flagSet.Set("flamingo-config", "baz: bam"))
 		require.NoError(t, flagSet.Set("flamingo-config", "foo.bar.test: 'hello'"))
+		defer func() { initFlagSet() }()
 		err := Load(root, "testdata/valid")
 		assert.NoError(t, err)
 		assert.Contains(t, root.Configuration.Flat(), "area")
@@ -77,6 +78,7 @@ func TestLoad(t *testing.T) {
 		root := new(Area)
 		assert.Panics(t, func() {
 			require.NoError(t, flagSet.Set("flamingo-config", "baz"))
+			defer func() { initFlagSet() }()
 
 			_ = Load(root, "testdata/valid")
 		})

--- a/framework/config/module.go
+++ b/framework/config/module.go
@@ -32,6 +32,10 @@ type (
 var flagSet *pflag.FlagSet
 
 func init() {
+	initFlagSet()
+}
+
+func initFlagSet() {
 	flagSet = pflag.NewFlagSet("flamingo.config", pflag.ContinueOnError)
 	flagSet.BoolVar(&debugLog, "flamingo-config-log", false, "enable flamingo config loader logging")
 	flagSet.StringArrayVar(&additionalConfig, "flamingo-config", []string{}, "add multiple flamingo config additions")


### PR DESCRIPTION
after manipulating the global flag set from within a test, it must be
reinitialized in tear down to assure an empty set for the next tests