### PR TITLE
core/gotemplate: Add engine tests, unlock mutex in case of error

### DIFF
--- a/core/gotemplate/engine.go
+++ b/core/gotemplate/engine.go
@@ -66,9 +66,7 @@ func (e *engine) Render(ctx context.Context, name string, data interface{}) (io.
 
 	lock.Lock()
 	if e.debug || e.templates == nil {
-
 		err := e.loadTemplates(ctx)
-
 		if err != nil {
 			lock.Unlock()
 			return nil, err

--- a/core/gotemplate/engine.go
+++ b/core/gotemplate/engine.go
@@ -64,14 +64,17 @@ func (e *engine) Render(ctx context.Context, name string, data interface{}) (io.
 	ctx, span := trace.StartSpan(ctx, "gotemplate/Render")
 	defer span.End()
 
+	lock.Lock()
 	if e.debug || e.templates == nil {
-		lock.Lock()
+
 		err := e.loadTemplates(ctx)
-		lock.Unlock()
+
 		if err != nil {
+			lock.Unlock()
 			return nil, err
 		}
 	}
+	lock.Unlock()
 
 	_, span = trace.StartSpan(ctx, "gotemplate/Execute")
 	buf := &bytes.Buffer{}

--- a/core/gotemplate/engine.go
+++ b/core/gotemplate/engine.go
@@ -64,14 +64,14 @@ func (e *engine) Render(ctx context.Context, name string, data interface{}) (io.
 	ctx, span := trace.StartSpan(ctx, "gotemplate/Render")
 	defer span.End()
 
-	lock.Lock()
 	if e.debug || e.templates == nil {
+		lock.Lock()
 		err := e.loadTemplates(ctx)
+		lock.Unlock()
 		if err != nil {
 			return nil, err
 		}
 	}
-	lock.Unlock()
 
 	_, span = trace.StartSpan(ctx, "gotemplate/Execute")
 	buf := &bytes.Buffer{}
@@ -110,7 +110,7 @@ func (e *engine) loadTemplates(ctx context.Context) error {
 		},
 		"map": func(p ...interface{}) map[string]interface{} {
 			res := make(map[string]interface{})
-			for i := 0; i < len(p); i += 2 {
+			for i := 0; i < len(p) && len(p)%2 == 0; i += 2 {
 				res[fmt.Sprint(p[i])] = p[i+1]
 			}
 			return res

--- a/core/gotemplate/engine_test.go
+++ b/core/gotemplate/engine_test.go
@@ -1,0 +1,183 @@
+package gotemplate
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"reflect"
+	"testing"
+	"time"
+
+	"flamingo.me/flamingo/v3/framework/flamingo"
+)
+
+var noAdditionalTemplateFuncs = func() map[string]flamingo.TemplateFunc {
+	return make(map[string]flamingo.TemplateFunc)
+}
+
+var additionalTemplateFuncs = func() map[string]flamingo.TemplateFunc {
+	funcs := make(map[string]flamingo.TemplateFunc)
+	funcs["customTemplateFunc"] = CustomTemplateFunc{}
+	return funcs
+}
+
+type CustomTemplateFunc struct{}
+
+var _ flamingo.TemplateFunc = CustomTemplateFunc{}
+
+func (CustomTemplateFunc) Func(ctx context.Context) interface{} {
+	return func() interface{} {
+		return "test-abc"
+	}
+}
+
+func Test_engine_Render(t *testing.T) {
+	type fields struct {
+		templatesBasePath  string
+		layoutTemplatesDir string
+		debug              bool
+		tplFuncs           func() map[string]flamingo.TemplateFunc
+	}
+	type args struct {
+		name string
+		data interface{}
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    io.Reader
+		wantErr bool
+	}{
+		{
+			name: "Template base path not found",
+			fields: fields{
+				templatesBasePath: "non-existing-dir/",
+				tplFuncs:          noAdditionalTemplateFuncs,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Layout path not found",
+			fields: fields{
+				templatesBasePath:  "testdata/test-simple",
+				layoutTemplatesDir: "non-existing-layout-dir",
+				tplFuncs:           noAdditionalTemplateFuncs,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Template not found",
+			fields: fields{
+				templatesBasePath:  "testdata/test-simple",
+				layoutTemplatesDir: "",
+				debug:              false,
+				tplFuncs:           noAdditionalTemplateFuncs,
+			},
+			args: args{
+				name: "non-existing-template",
+				data: nil,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Simple template found and working",
+			fields: fields{
+				templatesBasePath:  "testdata/test-simple",
+				layoutTemplatesDir: "",
+				debug:              false,
+				tplFuncs:           noAdditionalTemplateFuncs,
+			},
+			args: args{
+				name: "simple",
+				data: nil,
+			},
+			want:    bytes.NewBuffer([]byte("Hello World!")),
+			wantErr: false,
+		},
+		{
+			name: "Built in template functions work",
+			fields: fields{
+				templatesBasePath:  "testdata/test-simple",
+				layoutTemplatesDir: "",
+				debug:              false,
+				tplFuncs:           noAdditionalTemplateFuncs,
+			},
+			args: args{
+				name: "built-in-template-funcs",
+				data: struct {
+					Time time.Time
+				}{time.Unix(0, 0)},
+			},
+			want: bytes.NewBuffer([]byte(
+				`Upper: HELLO WORLD!
+formatDate: 1970-01-01
+map (invalid params): map[]
+map (valid params): map[a:b x:y]`)),
+			wantErr: false,
+		},
+		{
+			name: "Additional template functions work",
+			fields: fields{
+				templatesBasePath:  "testdata/test-simple",
+				layoutTemplatesDir: "",
+				debug:              false,
+				tplFuncs:           additionalTemplateFuncs,
+			},
+			args: args{
+				name: "additional-template-funcs",
+				data: struct {
+					Time time.Time
+				}{time.Unix(0, 0)},
+			},
+			want: bytes.NewBuffer([]byte(
+				`Upper: HELLO WORLD!
+formatDate: 1970-01-01
+map (invalid params): map[]
+map (valid params): map[a:b x:y]
+customTemplateFunc: test-abc`)),
+			wantErr: false,
+		},
+		{
+			name: "Nested layouts/templates should work",
+			fields: fields{
+				templatesBasePath:  "testdata/test-nested-dirs",
+				layoutTemplatesDir: "layouts",
+				debug:              false,
+				tplFuncs:           additionalTemplateFuncs,
+			},
+			args: args{
+				name: "dir-a/sub-dir-a/main",
+				data: nil,
+			},
+			want: bytes.NewBuffer([]byte(
+				`<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>Title</title></head><body><div>Hello World!</div></body></html>
+
+`)),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &engine{}
+			e.Inject(tt.fields.tplFuncs, flamingo.NullLogger{}, &struct {
+				TemplatesBasePath  string `inject:"config:gotemplates.engine.templates.basepath"`
+				LayoutTemplatesDir string `inject:"config:gotemplates.engine.layout.dir"`
+				Debug              bool   `inject:"config:debug.mode"`
+			}{
+				tt.fields.templatesBasePath,
+				tt.fields.layoutTemplatesDir,
+				tt.fields.debug,
+			})
+			got, err := e.Render(context.Background(), tt.args.name, tt.args.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Render() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Render() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/core/gotemplate/testdata/test-nested-dirs/dir-a/sub-dir-a/main.html
+++ b/core/gotemplate/testdata/test-nested-dirs/dir-a/sub-dir-a/main.html
@@ -1,0 +1,2 @@
+{{template "dir-a/layout1.html" .}}
+{{define "content"}}Hello World!{{end}}

--- a/core/gotemplate/testdata/test-nested-dirs/layouts/base.html
+++ b/core/gotemplate/testdata/test-nested-dirs/layouts/base.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>Title</title></head><body>{{template "main" .}}</body></html>

--- a/core/gotemplate/testdata/test-nested-dirs/layouts/dir-a/layout1.html
+++ b/core/gotemplate/testdata/test-nested-dirs/layouts/dir-a/layout1.html
@@ -1,0 +1,2 @@
+{{template "base.html" .}}
+{{define "main"}}<div>{{template "content" .}}</div>{{end}}

--- a/core/gotemplate/testdata/test-simple/additional-template-funcs.html
+++ b/core/gotemplate/testdata/test-simple/additional-template-funcs.html
@@ -1,0 +1,5 @@
+Upper: {{Upper "Hello World!"}}
+formatDate: {{formatDate .Time}}
+map (invalid params): {{map "not enough params"}}
+map (valid params): {{map "a" "b" "x" "y"}}
+customTemplateFunc: {{ customTemplateFunc }}

--- a/core/gotemplate/testdata/test-simple/additional-template-funcs.html
+++ b/core/gotemplate/testdata/test-simple/additional-template-funcs.html
@@ -1,5 +1,5 @@
 Upper: {{Upper "Hello World!"}}
 formatDate: {{formatDate .Time}}
 map (invalid params): {{map "not enough params"}}
-map (valid params): {{map "a" "b" "x" "y"}}
+map (valid params): {{map "x" "y"}}
 customTemplateFunc: {{ customTemplateFunc }}

--- a/core/gotemplate/testdata/test-simple/built-in-template-funcs.html
+++ b/core/gotemplate/testdata/test-simple/built-in-template-funcs.html
@@ -1,0 +1,4 @@
+Upper: {{Upper "Hello World!"}}
+formatDate: {{formatDate .Time}}
+map (invalid params): {{map "not enough params"}}
+map (valid params): {{map "a" "b" "x" "y"}}

--- a/core/gotemplate/testdata/test-simple/built-in-template-funcs.html
+++ b/core/gotemplate/testdata/test-simple/built-in-template-funcs.html
@@ -1,4 +1,4 @@
 Upper: {{Upper "Hello World!"}}
 formatDate: {{formatDate .Time}}
 map (invalid params): {{map "not enough params"}}
-map (valid params): {{map "a" "b" "x" "y"}}
+map (valid params): {{map "a" "b"}}

--- a/core/gotemplate/testdata/test-simple/simple.html
+++ b/core/gotemplate/testdata/test-simple/simple.html
@@ -1,0 +1,1 @@
+{{printf "%s" "Hello World!"}}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6
 	github.com/gomodule/redigo v2.0.0+incompatible
-	github.com/google/go-cmp v0.3.1 // indirect
+	github.com/google/go-cmp v0.3.1
 	github.com/gorilla/mux v1.7.3 // indirect
 	github.com/gorilla/sessions v1.1.3
 	github.com/hashicorp/golang-lru v0.5.3


### PR DESCRIPTION
Add tests for the engine
Fix mutex staying locked in case of error which can lead to a deadlock
Fix template function `map` causing out of bounds error if called with not enough arguments