### PR TITLE
move httpFrontent_test.go to cache_test package

### DIFF
--- a/core/cache/cache.go
+++ b/core/cache/cache.go
@@ -36,3 +36,12 @@ type (
 		span trace.SpanContext
 	}
 )
+
+// NewEntryMeta builds a new Meta Object for an CacheEntry
+func NewEntryMeta(lifetime time.Time, gracetime time.Time, tags []string) Meta {
+	return Meta{
+		lifetime:  lifetime,
+		gracetime: gracetime,
+		Tags:      tags,
+	}
+}


### PR DESCRIPTION
This is just an cosmetic pr. To be able to move HttpFrontent_test.go from the cache-package to the cache_test-packed, i needed to do some small refactorings:

- factory cache.NewEntryMeta: needed to build an Meta-Object inside tests
- exported cache.cachedResponse struct: needed to convert an interface to cache.CachedRepsonse conversion inside the tests
- factory cache.NewCachedResponse: needed to build an CachedResponse inside tests
- getter cache.CachedResponse.Body(): needed to compare the cache-results inside tests

As far as i can see, the changes are backward-compatible and hotfix-version compatible (correct me if i am wrong ;)).

Just cosmetic, but from my point of view unit-tests should be always in additional packages.