### PR TITLE
dingo injector is initialised 2 times when prefixrouter module is required

### DIFF
--- a/framework/config/area.go
+++ b/framework/config/area.go
@@ -266,6 +266,10 @@ func resolveDependencies(modules []dingo.Module, known map[reflect.Type]struct{}
 // GetInitializedInjector returns initialized container based on the configuration
 // we derive our injector from our parent
 func (area *Area) GetInitializedInjector() (*dingo.Injector, error) {
+	if area.Injector != nil {
+		return area.Injector, nil
+	}
+
 	var injector *dingo.Injector
 	if area.Parent != nil {
 		injector = area.Parent.Injector.Child()


### PR DESCRIPTION
In case when prefixrouter module is required, dingo injector is initialised two times, which means that Config methods from all modules are called multiple times as well.

This call error message in logging (not panic, but just error logging) for module https://github.com/i-love-flamingo/domainserviceintercept because there is server initialisation in Config method of dsi module.

