### PR TITLE
config: Fix config loading from CONTEXTFILE env

### DIFF
--- a/framework/config/Readme.md
+++ b/framework/config/Readme.md
@@ -68,12 +68,12 @@ Will cause Flamingo to additionally load the config files "config/config_dev.yml
 
 ### Additional configuration files from outside
 
-Flamingo can load multiple additional yaml files, which must be given in the environment variable `CONTEXTFILE`, separated by `:`.
+Flamingo can load multiple additional yaml/cue files, which must be given in the environment variable `CONTEXTFILE`, separated by `:`.
 
 The files can be given by using relative paths from the working directory or absolute paths.
 
 ```bash
-CONTEXTFILE="../../myCfg.yml:/var/flamingo/cfg/main.yml" go run project.go serve
+CONTEXTFILE="../../myCfg.yml:/var/flamingo/cfg/main.yml:/var/flamingo/cfg/additional.cue" go run project.go serve
 ```
 
 ### Additional temporary configuration

--- a/framework/config/loader.go
+++ b/framework/config/loader.go
@@ -82,6 +82,7 @@ func loadConfigFromBasedir(root *Area, config *LoadConfig) error {
 
 	// load additional single context file
 	for _, file := range strings.Split(os.Getenv("CONTEXTFILE"), ":") {
+		file = strings.TrimSuffix(file, filepath.Ext(file))
 		if file == "" {
 			continue
 		}

--- a/framework/config/loader.go
+++ b/framework/config/loader.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 
+	"cuelang.org/go/cue/build"
 	"cuelang.org/go/cue/format"
 	"github.com/ghodss/yaml"
 )
@@ -154,6 +155,12 @@ func loadCueFile(area *Area, filename string) error {
 	if err != nil {
 		return nil
 	}
+
+	if area.cueBuildInstance == nil {
+		cueContext := build.NewContext()
+		area.cueBuildInstance = cueContext.NewInstance(area.Name, nil)
+	}
+
 	return area.cueBuildInstance.AddFile(filename+".cue", nil)
 }
 

--- a/framework/config/loader.go
+++ b/framework/config/loader.go
@@ -168,10 +168,16 @@ var regex = regexp.MustCompile(`%%ENV:([^%\n]+)%%(([^%\n]+)%%)?`)
 
 func loadYamlFile(area *Area, filename string) error {
 	config, err := ioutil.ReadFile(filename + ".yml")
-	if err != nil {
-		return err
+	if err == nil {
+		return loadYamlConfig(area, config)
 	}
-	return loadYamlConfig(area, config)
+
+	config, err = ioutil.ReadFile(filename + ".yaml")
+	if err == nil {
+		return loadYamlConfig(area, config)
+	}
+
+	return err
 }
 
 func loadYamlConfig(area *Area, config []byte) error {

--- a/framework/config/testdata/contextfile/config_a.yml
+++ b/framework/config/testdata/contextfile/config_a.yml
@@ -1,0 +1,4 @@
+foo:
+  bar:
+    test: override
+    new: test

--- a/framework/config/testdata/contextfile/context.yaml
+++ b/framework/config/testdata/contextfile/context.yaml
@@ -1,0 +1,4 @@
+foo:
+  bar:
+    new: new
+new: test

--- a/framework/config/testdata/contextfile/cuetest.cue
+++ b/framework/config/testdata/contextfile/cuetest.cue
@@ -1,0 +1,4 @@
+foo: bar: {
+	test: "override" // only the value of config_a.yml should be possible anymore
+	new: string
+}


### PR DESCRIPTION
This PR fixes various issues introduced during the new cue config refactoring:

- CONTEXTFILE contains the full file path including the extension. To be backward compatible, we have to remove the extension, because the current solution adds an extension that leads to path/to/file.yml.yml
- Loading cue files from CONTEXTFILE was not possible due to missing cueBuildInstance in the root area.
- Before the refactor you could use any file extension for the additional config files, we should now at least support .yml and .yaml, since both are widely used and the latter is preferred according to https://yaml.org/faq.html.
- Test cases / test data for CONTEXTFILE were missing