### PR TITLE
Extract app init

### DIFF
--- a/app_before1.13.go
+++ b/app_before1.13.go
@@ -1,0 +1,14 @@
+//+build !go1.13
+
+package flamingo
+
+import (
+	"fmt"
+	"strings"
+)
+
+func init() {
+	fmtErrorf = func(format string, a ...interface{}) error {
+		return fmt.Errorf(strings.Replace(format, "%w", "%v", 1), a...)
+	}
+}


### PR DESCRIPTION
For better black box testing of an Flamingo App its currently hard to run an App with the core logic - since everything happens inside App() method 


If we split the logic its possible to get an fully initialized area (that can be used to get initialised injector etc)