### PR TITLE
framework/prefixrouter: Fix wrong legacy config alias

### DIFF
--- a/framework/prefixrouter/module.go
+++ b/framework/prefixrouter/module.go
@@ -61,8 +61,8 @@ if flamingo.prefixrouter.rootRedirectHandler.enabled {
 // FlamingoLegacyConfigAlias legacy mapping
 func (*Module) FlamingoLegacyConfigAlias() map[string]string {
 	return map[string]string{
-		"prefixrouter.rootRedirectHandler.enabled":             "flamingo.prefixrouter.rootRedirectHandler.enabled",
-		"prefixrouter.rootRedirectHandler.rootRedirectHandler": "flamingo.prefixrouter.rootRedirectHandler.rootRedirectHandler",
+		"prefixrouter.rootRedirectHandler.enabled":        "flamingo.prefixrouter.rootRedirectHandler.enabled",
+		"prefixrouter.rootRedirectHandler.redirectTarget": "flamingo.prefixrouter.rootRedirectHandler.redirectTarget",
 	}
 }
 


### PR DESCRIPTION
Using the legacy config for the prefixrouter currently leads to the following error due to wrong path:
`app: config load: root: cue: marshal error at path flamingo.prefixrouter.rootRedirectHandler.redirectTarget: cannot convert incomplete value "string" to JSON`