### PR TITLE
add base path to ServerErrorResponse

### DIFF
--- a/framework/web/result.go
+++ b/framework/web/result.go
@@ -377,6 +377,7 @@ func (r *Responder) ServerErrorWithCodeAndTemplate(err error, tpl string, status
 			engine:   r.engine,
 			DataResponse: DataResponse{
 				Data: map[string]interface{}{
+					"base":  r.router.base.Path,
 					"code":  status,
 					"error": errstr,
 				},


### PR DESCRIPTION
The root path in my project is configurable via
flamingo.router.path: %%ENV:BASE_PATH%%/gateway/%%

My error pages are static HTML. So, if the above path changes all CSS and assets of my error pages won't be found anymore.
Having base available in the DataResponse would allow me to set the path "dynamically" in my static HMTL like so: <base href="{{ .base }}/">

Considering all other options and given this is an edge case for a Flamingo environment, I find this to be the least invasive option to the problem.

Thanks for approving my request!