### PR TITLE
oauth: Rework log levels to avoid log pollution

### DIFF
--- a/core/oauth/application/authmanager.go
+++ b/core/oauth/application/authmanager.go
@@ -135,7 +135,7 @@ func (am *AuthManager) Auth(c context.Context, session *web.Session) (domain.Aut
 	if !currentToken.Valid() {
 		err := am.refreshTokenAndUpdateStore(c, session)
 		if err != nil {
-			am.logger.WithContext(c).Error(err)
+			am.logger.WithContext(c).Debug(err)
 			return domain.Auth{}, err
 		}
 	}

--- a/core/oauth/interfaces/callback_controller.go
+++ b/core/oauth/interfaces/callback_controller.go
@@ -69,7 +69,10 @@ func (cc *CallbackController) Get(ctx context.Context, request *web.Request) web
 	defer cc.authManager.DeleteAuthState(request.Session())
 
 	if state, ok := cc.authManager.LoadAuthState(request.Session()); !ok || state != request.Request().URL.Query().Get("state") {
-		cc.logger.Error(fmt.Sprintf("Invalid State - expected: %v  got: %v", state, request.Request().URL.Query().Get("state")))
+		if state != "" {
+			cc.logger.Error(fmt.Sprintf("Invalid State - expected: %v  got: %v", state, request.Request().URL.Query().Get("state")))
+		}
+
 		stats.Record(ctx, loginFailedCount.M(1))
 		return cc.responder.ServerError(errors.New("Invalid State"))
 	}


### PR DESCRIPTION
As long as the abandoned auth manager isn't replaced by the new auth module, we will reduce the log level of errors during token refresh from Error to Debug.