### PR TITLE
docs: fix missing/broken links

### DIFF
--- a/docs/0. Introduction/1. Getting Started.md
+++ b/docs/0. Introduction/1. Getting Started.md
@@ -3,7 +3,7 @@
 ## Hello World Example
 If you want to see a very simple and basic Flamingo application then follow these steps:
 
-1. Make sure you have go > 1.11 installed: https://golang.org/doc/install
+1. Make sure you have go >= 1.13 installed: https://golang.org/doc/install
 
 2. Get the Flamingo "example-helloworld".
     ```
@@ -67,5 +67,5 @@ go run main.go
 ## Read through the Manuals
 
 * Learn about all [Flamingo Basics](../2. Flamingo Core/1. Flamingo Basics/2. Flamingo Project Structure.html)
-* Learn [Flamingo Framework Modules](../2. Flamingo Core/2. Framework Modules/Configuration.html)
-* Learn [Flamingo Core Modules](../2. Flamingo Core/3. Core Modules/Cache.html)
+* Learn [Flamingo Framework Module Features](../2. Flamingo Core/2. Framework Modules/Configuration.html)
+* Learn [Flamingo Core Module Features](../2. Flamingo Core/3. Core Modules/Cache.html)

--- a/docs/0. Introduction/1. Getting Started.md
+++ b/docs/0. Introduction/1. Getting Started.md
@@ -3,7 +3,7 @@
 ## Hello World Example
 If you want to see a very simple and basic Flamingo application then follow these steps:
 
-1. Make sure you have go >= 1.13 installed: https://golang.org/doc/install
+1. Make sure you have Go >= 1.13 installed: https://golang.org/doc/install
 
 2. Get the Flamingo "example-helloworld".
     ```
@@ -13,7 +13,7 @@ If you want to see a very simple and basic Flamingo application then follow thes
     ```
     cd example-helloworld
     ```
-    Your entrypoint is `main.go`, this is where the application is started. 
+    Your entry point is `main.go`, this is where the application is started. 
     During the first run, go will download all dependencies. 
     Flamingo uses [go modules](https://github.com/golang/go/wiki/Modules) for this.
         
@@ -61,7 +61,7 @@ go run main.go
 
 * Start with [Hello World Tutorial](./2. Tutorial Hello World.md) to build your "Hello World" example step by step and learn some of flamingo features.
 * Continue with [Hello Flamingo Carotene](https://github.com/i-love-flamingo/example-flamingo-carotene) to learn the features of the pug template engine and the flamingo-carotene frontend pipeline.
-* Continue with [Open Weather Example](https://github.com/i-love-flamingo/example-openweather) to learn how to build a application that connects to an external service step by step.
+* Continue with [Open Weather Example](https://github.com/i-love-flamingo/example-openweather) to learn how to build an application that connects to an external service step by step.
 
 
 ## Read through the Manuals

--- a/docs/0. Introduction/1. Getting Started.md
+++ b/docs/0. Introduction/1. Getting Started.md
@@ -60,15 +60,12 @@ go run main.go
 ## How to continue
 
 * Start with [Hello World Tutorial](./2. Tutorial Hello World.md) to build your "Hello World" example step by step and learn some of flamingo features.
-* Continue with [Hello Flamingo Carotine]() to learn the features of the pug template engine and the flamingo-carotene frontend pipeline.
-* Continue with [Open Weather Example]() to learn how to build a application that connects to an external service step by step.
+* Continue with [Hello Flamingo Carotene](https://github.com/i-love-flamingo/example-flamingo-carotene) to learn the features of the pug template engine and the flamingo-carotene frontend pipeline.
+* Continue with [Open Weather Example](https://github.com/i-love-flamingo/example-openweather) to learn how to build a application that connects to an external service step by step.
 
-[todo]: <> (add links)
 
 ## Read through the Manuals
 
-* Learn about all [Flamingo Basics](../1. Flamingo Basics/)
-* Learn Flamingo Framework Module Features [Flamingo Basics](../2. Framework Modules/)
-* Learn Flamingo Core Module Features [Flamingo Basics](../3. Core Modules/)
-
-[todo]: <> (links to folders don't work)
+* Learn about all [Flamingo Basics](../2. Flamingo Core/1. Flamingo Basics/2. Flamingo Project Structure.html)
+* Learn [Flamingo Framework Modules](../2. Flamingo Core/2. Framework Modules/Configuration.html)
+* Learn [Flamingo Core Modules](../2. Flamingo Core/3. Core Modules/Cache.html)

--- a/docs/1. Flamingo Basics/2. Flamingo Project Structure.md
+++ b/docs/1. Flamingo Basics/2. Flamingo Project Structure.md
@@ -80,5 +80,5 @@ Learn more:
 Different example projects are provided in separate repositories.
 
 * [Hello World Tutorial](../../1. Introduction/2. Tutorial Hello World.md)
-* [Hello Flamingo Carotine]()
-* [Open Weather Example]()
+* [Hello Flamingo Carotene](https://github.com/i-love-flamingo/example-flamingo-carotene)
+* [Open Weather Example](https://github.com/i-love-flamingo/example-openweather)


### PR DESCRIPTION
Fix the broken links in the Flamingo documentation