### PR TITLE
add systemserver version endpoint

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,3 @@
-
 # Flamingo Framework
 
 <img align="right" width="159px" src="https://raw.githubusercontent.com/i-love-flamingo/flamingo/master/docs/assets/flamingo-logo-only-pink-on-white.png">

--- a/examples/dist/Dockerfile
+++ b/examples/dist/Dockerfile
@@ -4,7 +4,8 @@
 FROM golang:alpine AS builder
 RUN apk update && apk add --no-cache ca-certificates tzdata git && update-ca-certificates
 COPY . /app
-RUN cd /app && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o app .
+ARG APPVERSION=develop
+RUN cd /app && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X flamingo.me/flamingo/v3/framework/flamingo.appVersion=${APPVERSION}" -o app .
 
 # Final image
 FROM scratch

--- a/framework/flamingo/flamingo.go
+++ b/framework/flamingo/flamingo.go
@@ -1,0 +1,9 @@
+package flamingo
+
+var appVersion = "develop"
+
+// AppVersion returns the application version
+// set this during build with `go build -ldflags "-X flamingo.me/flamingo/v3/framework/flamingo.appVersion=1.2.3"`.
+func AppVersion() string {
+	return appVersion
+}

--- a/framework/systemendpoint/application/server.go
+++ b/framework/systemendpoint/application/server.go
@@ -3,7 +3,10 @@ package application
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
+	"runtime"
+	"runtime/debug"
 
 	"flamingo.me/flamingo/v3/framework/flamingo"
 	"flamingo.me/flamingo/v3/framework/systemendpoint/domain"
@@ -54,6 +57,20 @@ func (s *SystemServer) Start() {
 			serveMux.Handle(route, handler)
 		}
 	}
+
+	serveMux.HandleFunc("/version", func(writer http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(writer, "version: %s\n", flamingo.AppVersion())
+		fmt.Fprintf(writer, "go: %s\n", runtime.Version())
+		if info, ok := debug.ReadBuildInfo(); ok {
+			fmt.Fprintf(writer, "path: %s\n", info.Path)
+			for _, module := range info.Deps {
+				if module.Path == "flamingo.me/flamingo/v3" {
+					fmt.Fprintf(writer, "flamingo: %s\n", module.Version)
+				}
+			}
+		}
+	})
+
 	s.server = &http.Server{Addr: s.serviceAddress, Handler: serveMux}
 	go func() {
 		err := s.server.ListenAndServe()


### PR DESCRIPTION
Example:
```
go build -ldflags "-X flamingo.me/flamingo/v3/framework/flamingo.appVersion=1.5.3-321" -o app .
```
Result:
```
version: 1.5.3-321
go: go1.14.4
path: flamingo.me/test/example-portal
flamingo: v3.1.7-0.20200128092458-a827e5897b01
```