### PR TITLE
framework/config: add printError before panic

### DIFF
--- a/framework/config/config_test.go
+++ b/framework/config/config_test.go
@@ -15,9 +15,9 @@ func readConfig(t *testing.T, configName string) Map {
 	config, err := ioutil.ReadFile(configName)
 	assert.NoError(t, err)
 
-	config = []byte(regex.ReplaceAllStringFunc(
+	config = []byte(envRegex.ReplaceAllStringFunc(
 		string(config),
-		func(a string) string { return os.Getenv(regex.FindStringSubmatch(a)[1]) },
+		func(a string) string { return os.Getenv(envRegex.FindStringSubmatch(a)[1]) },
 	))
 
 	cfg := make(Map)


### PR DESCRIPTION
In case the config parsing fails flamingo panics.

Would be helpful to see the context (print the error lines)
