### PR TITLE
oauth: cleanup session data on login callback

### DIFF
--- a/core/oauth/interfaces/callback_controller.go
+++ b/core/oauth/interfaces/callback_controller.go
@@ -77,6 +77,9 @@ func (cc *CallbackController) Get(ctx context.Context, request *web.Request) web
 		return cc.responder.ServerError(errors.New("Invalid State"))
 	}
 
+	// cleanup previous token information
+	cc.authManager.DeleteTokenDetails(request.Session())
+
 	code := request.Request().URL.Query().Get("code")
 	errCode := request.Request().URL.Query().Get("error")
 


### PR DESCRIPTION
Its possible to use multiple logins on the same device, for this case the previous session data should be cleaned up on a fresh login callback.