### PR TITLE
better handling of server closing during graceful shutdown

### DIFF
--- a/app.go
+++ b/app.go
@@ -360,7 +360,7 @@ func serveProvider(a *servemodule, logger flamingo.Logger) *cobra.Command {
 			err := a.listenAndServe()
 			if err != nil {
 				if err == http.ErrServerClosed {
-					logger.Error(err)
+					logger.Info(err)
 				} else {
 					logger.Fatal("unexpected error in serving:", err)
 				}

--- a/framework/systemendpoint/application/server.go
+++ b/framework/systemendpoint/application/server.go
@@ -81,8 +81,9 @@ func (s *SystemServer) Start() {
 }
 
 func (s *SystemServer) shutdown() {
-	s.logger.Info("systemendpoint: shutdown at ", s.serviceAddress)
 	if s.server != nil {
+		s.logger.Info("systemendpoint: shutdown at ", s.serviceAddress)
 		_ = s.server.Shutdown(context.Background())
+		s.server = nil
 	}
 }


### PR DESCRIPTION
* prevent system endpoint shutdown from being called multiple times
* degrade loglevel of main server shutdown to info, since this is the expected behaviour on SIGINT or SIGTERM