### PR TITLE
framework/web: add handler as part of request

### DIFF
--- a/framework/web/handler.go
+++ b/framework/web/handler.go
@@ -112,7 +112,9 @@ func (h *handler) ServeHTTP(rw http.ResponseWriter, httpRequest *http.Request) {
 	_, span = trace.StartSpan(ctx, "router/matchRequest")
 	controller, params, handler := h.routerRegistry.matchRequest(httpRequest)
 
+	var handlerName string
 	if handler != nil {
+		handlerName = handler.handler
 		ctx, _ = tag.New(ctx, tag.Upsert(ControllerKey, handler.GetHandlerName()), tag.Insert(opencensus.KeyArea, "-"))
 		httpRequest = httpRequest.WithContext(ctx)
 		start := time.Now()
@@ -122,9 +124,10 @@ func (h *handler) ServeHTTP(rw http.ResponseWriter, httpRequest *http.Request) {
 	}
 
 	req := &Request{
-		request: *httpRequest,
-		session: Session{s: session.s, sessionSaveMode: session.sessionSaveMode},
-		Params:  params,
+		request:     *httpRequest,
+		session:     Session{s: session.s, sessionSaveMode: session.sessionSaveMode},
+		handlerName: handlerName,
+		Params:      params,
 	}
 	ctx = ContextWithRequest(ContextWithSession(ctx, req.Session()), req)
 

--- a/framework/web/handler.go
+++ b/framework/web/handler.go
@@ -112,9 +112,7 @@ func (h *handler) ServeHTTP(rw http.ResponseWriter, httpRequest *http.Request) {
 	_, span = trace.StartSpan(ctx, "router/matchRequest")
 	controller, params, handler := h.routerRegistry.matchRequest(httpRequest)
 
-	var handlerName string
 	if handler != nil {
-		handlerName = handler.handler
 		ctx, _ = tag.New(ctx, tag.Upsert(ControllerKey, handler.GetHandlerName()), tag.Insert(opencensus.KeyArea, "-"))
 		httpRequest = httpRequest.WithContext(ctx)
 		start := time.Now()
@@ -124,10 +122,10 @@ func (h *handler) ServeHTTP(rw http.ResponseWriter, httpRequest *http.Request) {
 	}
 
 	req := &Request{
-		request:     *httpRequest,
-		session:     Session{s: session.s, sessionSaveMode: session.sessionSaveMode},
-		handlerName: handlerName,
-		Params:      params,
+		request: *httpRequest,
+		session: Session{s: session.s, sessionSaveMode: session.sessionSaveMode},
+		Handler: handler,
+		Params:  params,
 	}
 	ctx = ContextWithRequest(ContextWithSession(ctx, req.Session()), req)
 

--- a/framework/web/request.go
+++ b/framework/web/request.go
@@ -12,10 +12,11 @@ import (
 type (
 	// Request object stores the actual HTTP Request, Session, Params and attached Values
 	Request struct {
-		request http.Request
-		session Session
-		Params  RequestParams
-		Values  sync.Map
+		request     http.Request
+		session     Session
+		handlerName string
+		Params      RequestParams
+		Values      sync.Map
 	}
 
 	// RequestParams store string->string values for request data
@@ -144,4 +145,14 @@ func (r *Request) Query1(name string) (string, error) {
 // QueryAll returns a Map of the Raw Query
 func (r *Request) QueryAll() url.Values {
 	return r.request.URL.Query()
+}
+
+// HandlerName returns a Name of found handler
+func (r *Request) HandlerName() string {
+	return r.handlerName
+}
+
+// HasHandler checks if there is a handler for request
+func (r *Request) HasHandler() bool {
+	return r.handlerName != ""
 }

--- a/framework/web/request.go
+++ b/framework/web/request.go
@@ -12,11 +12,11 @@ import (
 type (
 	// Request object stores the actual HTTP Request, Session, Params and attached Values
 	Request struct {
-		request     http.Request
-		session     Session
-		handlerName string
-		Params      RequestParams
-		Values      sync.Map
+		request http.Request
+		session Session
+		Handler *Handler
+		Params  RequestParams
+		Values  sync.Map
 	}
 
 	// RequestParams store string->string values for request data
@@ -147,12 +147,7 @@ func (r *Request) QueryAll() url.Values {
 	return r.request.URL.Query()
 }
 
-// HandlerName returns a Name of found handler
-func (r *Request) HandlerName() string {
-	return r.handlerName
-}
-
 // HasHandler checks if there is a handler for request
 func (r *Request) HasHandler() bool {
-	return r.handlerName != ""
+	return r.Handler != nil
 }


### PR DESCRIPTION
This code adds handler name attribute to web.Request and so possibility to have information if there is assigned handler and it's name later in ChainFilter, Middleware or Controller.