### PR TITLE
framework/web: add sorting option for filters

### DIFF
--- a/framework/web/docs/ReadmeRouter.md
+++ b/framework/web/docs/ReadmeRouter.md
@@ -194,6 +194,8 @@ The filters are handled in order of `dingo.Modules` as defined in `flamingo.App(
 You will have to return `fc.Next(ctx, req, w)` in your `Filter` function to call the next filter. If you return something else,
 the chain will be aborted and the actual controller action will not be executed.
 
+A filter can prioritized if it implements interface `web.PrioritizedFilter`, by providing additional method `Priority() int`. By providing higher value, Filter will be executed earlier in a chain. Priority can be any integer number, positive or negative. In case Filter doesn't implement this interface, default priority value is `0`. 
+
 ## Routing config
 
 You can define the URL under which the routing takes place:

--- a/framework/web/filter.go
+++ b/framework/web/filter.go
@@ -94,23 +94,23 @@ func (sf sortableFilers) Swap(i, j int) {
 }
 
 func (sf sortableFilers) toFilters() []Filter {
-	var filters []Filter
+	filters := make([]Filter, len(sf))
 
-	for _, f := range sf {
-		filters = append(filters, f.filter)
+	for i, f := range sf {
+		filters[i] = f.filter
 	}
 
 	return filters
 }
 
 func newSortableFilters(filters []Filter) sortableFilers {
-	var result sortableFilers
+	result := make(sortableFilers, len(filters))
 
 	for i, f := range filters {
-		result = append(result, sortableFilter{
+		result[i] = sortableFilter{
 			filter: f,
 			index:  i,
-		})
+		}
 	}
 
 	return result

--- a/framework/web/filter_test.go
+++ b/framework/web/filter_test.go
@@ -1,0 +1,178 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockedFilter struct {
+	name string
+}
+
+func (f *mockedFilter) Filter(context.Context, *Request, http.ResponseWriter, *FilterChain) Result {
+	return new(Responder).Data(f.name)
+}
+
+type mockedPrioritizedFilter struct {
+	mockedFilter
+	priority int
+}
+
+func (f *mockedPrioritizedFilter) Priority() int {
+	return f.priority
+}
+
+func TestNewFilterChain(t *testing.T) {
+	testCases := []struct {
+		filters []Filter
+		sorted  []Filter
+	}{
+		{},
+		{
+			filters: []Filter{
+				&mockedFilter{
+					name: "first",
+				},
+				&mockedFilter{
+					name: "second",
+				},
+				&mockedFilter{
+					name: "third",
+				},
+			},
+			sorted: []Filter{
+				&mockedFilter{
+					name: "first",
+				},
+				&mockedFilter{
+					name: "second",
+				},
+				&mockedFilter{
+					name: "third",
+				},
+			},
+		},
+		{
+			filters: []Filter{
+				&mockedPrioritizedFilter{
+					mockedFilter: mockedFilter{
+						name: "first",
+					},
+					priority: -1,
+				},
+				&mockedFilter{
+					name: "second",
+				},
+				&mockedPrioritizedFilter{
+					mockedFilter: mockedFilter{
+						name: "third",
+					},
+					priority: 1,
+				},
+			},
+			sorted: []Filter{
+				&mockedPrioritizedFilter{
+					mockedFilter: mockedFilter{
+						name: "third",
+					},
+					priority: 1,
+				},
+				&mockedFilter{
+					name: "second",
+				},
+				&mockedPrioritizedFilter{
+					mockedFilter: mockedFilter{
+						name: "first",
+					},
+					priority: -1,
+				},
+			},
+		},
+		{
+			filters: []Filter{
+				&mockedPrioritizedFilter{
+					mockedFilter: mockedFilter{
+						name: "first",
+					},
+					priority: -1,
+				},
+				&mockedPrioritizedFilter{
+					mockedFilter: mockedFilter{
+						name: "second",
+					},
+					priority: -1,
+				},
+				&mockedPrioritizedFilter{
+					mockedFilter: mockedFilter{
+						name: "third",
+					},
+					priority: 0,
+				},
+				&mockedFilter{
+					name: "fourth",
+				},
+				&mockedFilter{
+					name: "fifth",
+				},
+				&mockedPrioritizedFilter{
+					mockedFilter: mockedFilter{
+						name: "sixth",
+					},
+					priority: 1,
+				},
+				&mockedPrioritizedFilter{
+					mockedFilter: mockedFilter{
+						name: "seventh",
+					},
+					priority: 1,
+				},
+			},
+			sorted: []Filter{
+				&mockedPrioritizedFilter{
+					mockedFilter: mockedFilter{
+						name: "sixth",
+					},
+					priority: 1,
+				},
+				&mockedPrioritizedFilter{
+					mockedFilter: mockedFilter{
+						name: "seventh",
+					},
+					priority: 1,
+				},
+				&mockedPrioritizedFilter{
+					mockedFilter: mockedFilter{
+						name: "third",
+					},
+					priority: 0,
+				},
+				&mockedFilter{
+					name: "fourth",
+				},
+				&mockedFilter{
+					name: "fifth",
+				},
+				&mockedPrioritizedFilter{
+					mockedFilter: mockedFilter{
+						name: "first",
+					},
+					priority: -1,
+				},
+				&mockedPrioritizedFilter{
+					mockedFilter: mockedFilter{
+						name: "second",
+					},
+					priority: -1,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		chain := NewFilterChain(nil, tc.filters...)
+		assert.Equal(t, tc.sorted, chain.filters)
+	}
+}

--- a/framework/web/filter_test.go
+++ b/framework/web/filter_test.go
@@ -37,7 +37,7 @@ func TestNewFilterChain(t *testing.T) {
 			sorted:  []Filter{},
 		},
 		{
-			name:    "default ordering in chain",
+			name: "default ordering in chain",
 			filters: []Filter{
 				&mockedFilter{
 					name: "first",
@@ -62,7 +62,7 @@ func TestNewFilterChain(t *testing.T) {
 			},
 		},
 		{
-			name:    "simple reordering in chain",
+			name: "simple reordering in chain",
 			filters: []Filter{
 				&mockedPrioritizedFilter{
 					mockedFilter: mockedFilter{
@@ -99,7 +99,7 @@ func TestNewFilterChain(t *testing.T) {
 			},
 		},
 		{
-			name:    "multiple filters with same priority",
+			name: "multiple filters with same priority",
 			filters: []Filter{
 				&mockedPrioritizedFilter{
 					mockedFilter: mockedFilter{

--- a/framework/web/filter_test.go
+++ b/framework/web/filter_test.go
@@ -30,7 +30,10 @@ func TestNewFilterChain(t *testing.T) {
 		filters []Filter
 		sorted  []Filter
 	}{
-		{},
+		{
+			filters: []Filter{},
+			sorted:  []Filter{},
+		},
 		{
 			filters: []Filter{
 				&mockedFilter{

--- a/framework/web/filter_test.go
+++ b/framework/web/filter_test.go
@@ -29,12 +29,15 @@ func TestNewFilterChain(t *testing.T) {
 	testCases := []struct {
 		filters []Filter
 		sorted  []Filter
+		name    string
 	}{
 		{
+			name:    "empty chain",
 			filters: []Filter{},
 			sorted:  []Filter{},
 		},
 		{
+			name:    "default ordering in chain",
 			filters: []Filter{
 				&mockedFilter{
 					name: "first",
@@ -59,6 +62,7 @@ func TestNewFilterChain(t *testing.T) {
 			},
 		},
 		{
+			name:    "simple reordering in chain",
 			filters: []Filter{
 				&mockedPrioritizedFilter{
 					mockedFilter: mockedFilter{
@@ -95,6 +99,7 @@ func TestNewFilterChain(t *testing.T) {
 			},
 		},
 		{
+			name:    "multiple filters with same priority",
 			filters: []Filter{
 				&mockedPrioritizedFilter{
 					mockedFilter: mockedFilter{
@@ -175,7 +180,9 @@ func TestNewFilterChain(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		chain := NewFilterChain(nil, tc.filters...)
-		assert.Equal(t, tc.sorted, chain.filters)
+		t.Run(tc.name, func(t *testing.T) {
+			chain := NewFilterChain(nil, tc.filters...)
+			assert.Equal(t, tc.sorted, chain.filters)
+		})
 	}
 }


### PR DESCRIPTION
Added option for web.Filter to be prioritised. By default, priority for all filters is 0, until it's specified differently. During web.ChainFilter initialisation, filters are stored in descending order.