### PR TITLE
servemodule: allow port configuration with flamingo config

### DIFF
--- a/app.go
+++ b/app.go
@@ -354,7 +354,7 @@ func (a *servemodule) Configure(injector *dingo.Injector) {
 
 // CueConfig for the module
 func (a *servemodule) CueConfig() string {
-	return `core: serve: port: number | *3322`
+	return `core: serve: port: >= 0 & <= 65535 | *3322`
 }
 
 func serveProvider(a *servemodule, logger flamingo.Logger) *cobra.Command {

--- a/app.go
+++ b/app.go
@@ -330,12 +330,15 @@ func (a *servemodule) Inject(
 	eventRouter flamingo.EventRouter,
 	logger flamingo.Logger,
 	configuredSampler *opencensus.ConfiguredURLPrefixSampler,
+	cfg *struct {
+		Port int `inject:"config:core.serve.port"`
+	},
 ) {
 	a.router = router
 	a.eventRouter = eventRouter
 	a.logger = logger
 	a.server = &http.Server{
-		Addr: ":3322",
+		Addr: fmt.Sprintf(":%d", cfg.Port),
 	}
 	a.configuredSampler = configuredSampler
 }
@@ -347,6 +350,11 @@ func (a *servemodule) Configure(injector *dingo.Injector) {
 	injector.BindMulti(new(cobra.Command)).ToProvider(func() *cobra.Command {
 		return serveProvider(a, a.logger)
 	})
+}
+
+// CueConfig for the module
+func (a *servemodule) CueConfig() string {
+	return `core: serve: port: number | *3322`
 }
 
 func serveProvider(a *servemodule, logger flamingo.Logger) *cobra.Command {
@@ -367,7 +375,7 @@ func serveProvider(a *servemodule, logger flamingo.Logger) *cobra.Command {
 			}
 		},
 	}
-	serveCmd.Flags().StringVarP(&a.server.Addr, "addr", "a", ":3322", "addr on which flamingo runs")
+	serveCmd.Flags().StringVarP(&a.server.Addr, "addr", "a", a.server.Addr, "addr on which flamingo runs")
 	serveCmd.Flags().StringVarP(&a.certFile, "certFile", "c", "", "certFile to enable HTTPS")
 	serveCmd.Flags().StringVarP(&a.keyFile, "keyFile", "k", "", "keyFile to enable HTTPS")
 


### PR DESCRIPTION
This change allows to configure the listened port with default flamingo config. I kept the `-a` parameter for the `serve` command for backward compatibility. We can think about removing it in the future, because it's possible to use the `--flamingo-config "core.serve.port: 3322"` parameter instead.