### PR TITLE
Added os.Exit after graceful shutdown is done

### DIFF
--- a/framework/cmd/module.go
+++ b/framework/cmd/module.go
@@ -101,6 +101,7 @@ func shutdown(eventRouter flamingo.EventRouter, signals <-chan os.Signal, comple
 	case <-stopper:
 		logger.Info("graceful shutdown complete")
 		complete <- struct{}{}
+		os.Exit(0)
 	}
 }
 


### PR DESCRIPTION
A running flamingo app cannot be stopped by CRTL-C, the grafeful shutdown is only triggered, but the app does not exit. 
This is a bit tedious as the PID needs to be fetched to kill -9 the app. 

I added `os.Exit(0)` again as soon as the shutdown is done...