### PR TITLE
framework: Fix graceful shutdown that was blocked by prefix router, avoid duplicated log's

### DIFF
--- a/app.go
+++ b/app.go
@@ -388,6 +388,10 @@ func (a *servemodule) listenAndServe() error {
 // Notify upon flamingo Shutdown event
 func (a *servemodule) Notify(ctx context.Context, event flamingo.Event) {
 	if _, ok := event.(*flamingo.ShutdownEvent); ok {
+		if a.server.Handler == nil {
+			// server not running, nothing to shut down
+			return
+		}
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 		a.logger.Info("Shutdown server on ", a.server.Addr)

--- a/framework/prefixrouter/module.go
+++ b/framework/prefixrouter/module.go
@@ -184,7 +184,7 @@ func (m *Module) listenAndServe() error {
 
 // Notify handles the app shutdown event
 func (m *Module) Notify(ctx context.Context, event flamingo.Event) {
-	if _, ok := event.(*flamingo.ServerShutdownEvent); ok {
+	if _, ok := event.(*flamingo.ShutdownEvent); ok {
 		if m.server == nil {
 			m.logger.WithField("category", "prefixrouter").Info("Shutdown: server not started.. ")
 			return


### PR DESCRIPTION
The prefix router module was listening to the wrong event and therefore was never shut down. This resulted in a hanging state after pressing CTRL+C.

Since there are two ways of shutting down a command (signal for infinite command, post-run for a finite command) using the signal lead to a duplicate call of the shutdown function/log output. This is now wrapped in sync. Once to only trigger the shutdown once.

In addition, the default serve command tried to shutdown it's server independent of if it was running, this is now also checked to avoid confusing log outputs.