### PR TITLE
core/auth: Fix potential redirect loop on login

### DIFF
--- a/core/auth/webidentity.go
+++ b/core/auth/webidentity.go
@@ -141,7 +141,7 @@ func (s *WebIdentityService) IdentifyAs(ctx context.Context, request *web.Reques
 func (s *WebIdentityService) storeRedirectURL(request *web.Request) {
 	redirecturl, ok := request.Params["redirecturl"]
 	if !ok || redirecturl == "" {
-		u, err := s.reverseRouter.Absolute(request, request.Request().URL.Path, nil)
+		u, err := s.reverseRouter.Absolute(request, "", nil)
 		if err == nil {
 			redirecturl = u.String()
 		}


### PR DESCRIPTION
When you call the login route you can either specify a redirect URL (via a query param) or the referer is taken into account.  [controller.go:36](https://github.com/i-love-flamingo/flamingo/blob/master/core/auth/controller.go#L36)

If you call the login route directly and don't provide the query param nor have a referer set, during saving of the redirect URL, a second fallback kicks in and takes the current URL and stores it as the redirect URL. [webidentity.go:143](https://github.com/i-love-flamingo/flamingo/blob/master/core/auth/webidentity.go#L143)

This second fallback leads to a redirect loop since after a successful login you are redirected back to the login and again and again...