### PR TITLE
core/auth: Expose RawIDToken as part of OpenIDIdentity interface

### DIFF
--- a/core/auth/mock/identity.go
+++ b/core/auth/mock/identity.go
@@ -24,6 +24,11 @@ type (
 	}
 )
 
+// RawIDToken returns a mocked raw id token
+func (i *OIDCIdentity) RawIDToken() string {
+	return "raw-id-token"
+}
+
 // Subject getter
 func (i *Identity) Subject() string {
 	return i.Sub

--- a/core/auth/oauth/oidc.go
+++ b/core/auth/oauth/oidc.go
@@ -25,6 +25,7 @@ type (
 		Identity
 		IDToken() *oidc.IDToken
 		IDTokenClaims(into interface{}) error
+		RawIDToken() string
 	}
 
 	oidcIdentity struct {

--- a/core/oauth/domain/user.go
+++ b/core/oauth/domain/user.go
@@ -46,6 +46,7 @@ type (
 	Auth struct {
 		TokenSource oauth2.TokenSource
 		IDToken     *oidc.IDToken
+		RawIDToken  string
 	}
 )
 

--- a/core/oauth/interfaces/legacyIdentifier.go
+++ b/core/oauth/interfaces/legacyIdentifier.go
@@ -94,8 +94,7 @@ func (identifier *LegacyIdentifier) Identify(ctx context.Context, request *web.R
 		return nil, err
 	}
 
-	rawIDToken, err := identifier.authmanager.GetRawIDToken(ctx, request.Session())
-
+	rawIDToken, _ := identifier.authmanager.GetRawIDToken(ctx, request.Session())
 	return &LegacyIdentity{auth: authData, rawIDToken: rawIDToken}, nil
 }
 

--- a/core/oauth/interfaces/legacyIdentifier.go
+++ b/core/oauth/interfaces/legacyIdentifier.go
@@ -16,7 +16,8 @@ import (
 
 // LegacyIdentity is an oauth.OIDCIdentifier for old oauth module
 type LegacyIdentity struct {
-	auth domain.Auth
+	auth       domain.Auth
+	rawIDToken string
 }
 
 var _ oauth.OpenIDIdentity = new(LegacyIdentity)
@@ -49,6 +50,11 @@ func (identity *LegacyIdentity) IDToken() *oidc.IDToken {
 // IDTokenClaims mapper
 func (identity *LegacyIdentity) IDTokenClaims(into interface{}) error {
 	return identity.auth.IDToken.Claims(into)
+}
+
+// RawIDToken returns the raw JWT id token
+func (identity *LegacyIdentity) RawIDToken() string {
+	return identity.rawIDToken
 }
 
 // LegacyIdentifier bridges core/oauth and core/auth/oauth together
@@ -88,7 +94,9 @@ func (identifier *LegacyIdentifier) Identify(ctx context.Context, request *web.R
 		return nil, err
 	}
 
-	return &LegacyIdentity{auth: authData}, nil
+	rawIDToken, err := identifier.authmanager.GetRawIDToken(ctx, request.Session())
+
+	return &LegacyIdentity{auth: authData, rawIDToken: rawIDToken}, nil
 }
 
 // Authenticate an incoming request with the logincontroller

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/ghodss/yaml v1.0.0
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 	github.com/golang/protobuf v1.3.3 // indirect
 	github.com/gomodule/redigo v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
+github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
@@ -193,6 +195,7 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1 h1:PJPDf8OUfOK1bb/NeTKd4f1QXZItOX389VN3B6qC8ro=
 github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
+github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -346,6 +349,7 @@ github.com/vektra/mockery v1.1.2/go.mod h1:VcfZjKaFOPO+MpN4ZvwPjs4c48lkq1o3Ym8yH
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zemirco/memorystore v0.0.0-20160308183530-ecd57e5134f6 h1:j+ZgVPhfLkC3WDIqNCSpU2/Y67d2FNohAjrxR3HV+KQ=
 github.com/zemirco/memorystore v0.0.0-20160308183530-ecd57e5134f6/go.mod h1:PLhuixMlky6sB4/LEnpp1//u2BcRF2pKUYXLMVyOrIc=
@@ -505,6 +509,8 @@ golang.org/x/tools v0.0.0-20200225230052-807dcd883420 h1:4RJNOV+2rLxMEfr6QIpC7GE
 golang.org/x/tools v0.0.0-20200225230052-807dcd883420/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200323144430-8dcfad9e016e h1:ssd5ulOvVWlh4kDSUF2SqzmMeWfjmwDXM+uGw/aQjRE=
 golang.org/x/tools v0.0.0-20200323144430-8dcfad9e016e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
+golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
In some cases you want to work with the raw JWT id token, it therefore makes sense to expose it directly via the interface. AccessToken and RefreshToken can already be reached with the TokenSource() function so this would be a nice addition.