### PR TITLE
ci: Remove Nancy from main pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,3 @@ jobs:
         run: |
           go generate ./...
           git diff --quiet || (echo 'generated go files are not up to date, check go generate, go.sum and go.mod' ; git diff ; exit 1)
-      - name: WriteGoList
-        run: go list -json -m all > go.list
-      - name: Nancy
-        uses: sonatype-nexus-community/nancy-github-action@main


### PR DESCRIPTION
Nancy currently prevents us from merging open pull requests, the vulnerabilities found mostly affect sub-dependencies we often have no control over. Sometimes it takes quite a long time until the maintainers of those packages publish a corresponding tag to which we can then update.

This PR removes Nancy from the main pipeline. The check is still running once a day.