### PR TITLE
core/locale: fix data race and improve devmode performance in translation service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Changelog
 
+## Upcoming
+
+- core/locale:
+  - fixed a race condition in `TranslationService`
+  - improved translation performance in flamingo debug mode
+
 ## v3.2.0
 
 - license:
   - Flamingo now uses the MIT license. The CLA has been removed.
 - core/auth:
-  - Flamingo v3.2.0 provides a new auth package which makes authentication easier an more canonical.
+  - Flamingo v3.2.0 provides a new auth package which makes authentication easier and more canonical.
   - the old core/oauth is deprecated and provides a compatibility layer for core/auth.
 - sessions:
   - web.SessionStore provides programmatic access to web.Session
@@ -26,7 +32,7 @@
 
 - "locale" package:
   - the templatefunc __(key) is now returning a Label and instead additional parameters you need to use the label setters (see doc)
-- Depricated Features are removed:
+- Deprecated Features are removed:
   - `flamingo.me/dingo` need to be used now
   - support for responder.*Aware types is removed
 - `framework/web.Response` is now `framework/web.Result`

--- a/core/locale/application/label_service.go
+++ b/core/locale/application/label_service.go
@@ -45,9 +45,9 @@ func (l *LabelService) NewLabel(key string) *domain.Label {
 
 // AllLabels return a array of all labels
 func (l *LabelService) AllLabels() []domain.Label {
-	var labels []domain.Label
 	tags := l.translationService.AllTranslationKeys(l.defaultLocaleCode)
 
+	labels := make([]domain.Label, 0, len(tags))
 	for _, tag := range tags {
 		label := l.NewLabel(tag)
 		if label != nil {

--- a/core/locale/infrastructure/translation_service.go
+++ b/core/locale/infrastructure/translation_service.go
@@ -17,7 +17,7 @@ import (
 
 // TranslationService is the default TranslationService implementation
 type TranslationService struct {
-	mutex sync.Mutex
+	mutex            sync.Mutex
 	lastReload       time.Time
 	translationFiles []string
 	logger           flamingo.Logger

--- a/core/locale/interfaces/controllers/translation_controller.go
+++ b/core/locale/interfaces/controllers/translation_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+
 	"flamingo.me/flamingo/v3/core/locale/application"
 	"flamingo.me/flamingo/v3/framework/web"
 )
@@ -29,9 +30,9 @@ func (c *TranslationController) Inject(
 
 // GetAllTranslations controller for TranslationController
 func (c *TranslationController) GetAllTranslations(ctx context.Context, r *web.Request) web.Result {
-	var translations []TranslationJSON
 	l := c.labelService.AllLabels()
 
+	translations := make([]TranslationJSON, 0, len(l))
 	for _, la := range l {
 		translations = append(translations, TranslationJSON{
 			Key:         la.GetKey(),

--- a/core/locale/module.go
+++ b/core/locale/module.go
@@ -45,10 +45,7 @@ func (r *routes) Inject(
 
 func (r *routes) Routes(registry *web.RouterRegistry) {
 	registry.HandleGet("api.translations", r.translationController.GetAllTranslations)
-	_, err := registry.Route("/api/translations", "api.translations")
-	if err != nil {
-		panic(err)
-	}
+	registry.MustRoute("/api/translations", "api.translations")
 }
 
 // CueConfig for this module
@@ -56,6 +53,8 @@ func (m *Module) CueConfig() string {
 	return `
 core: locale: {
 	locale: string | *"en-US"
+	translationFile: string | *""
+	translationFiles: [...string] | *[]
 	accounting: {
 		default: {
 			decimal: string | *"."


### PR DESCRIPTION
Fixes #188 and fixes #193. With the change we only reload the translations if one of the translationfiles changed. Only applies for debug mode, in production mode we still just load them once. 