### PR TITLE
framework/prefixrouter: Fix potential nil pointer when using malformed requests

### DIFF
--- a/framework/prefixrouter/front_router.go
+++ b/framework/prefixrouter/front_router.go
@@ -134,7 +134,13 @@ func (fr *FrontRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		r, _ := tag.New(req.Context(), tag.Upsert(opencensus.KeyArea, router.area))
 		req = req.WithContext(r)
 
-		req.URL, _ = url.Parse(path[len(prefix)-len(host):])
+		var err error
+		req.URL, err = url.Parse(path[len(prefix)-len(host):])
+		if err != nil {
+			w.WriteHeader(404)
+			return
+		}
+
 		req.URL.Path = "/" + strings.TrimLeft(req.URL.Path, "/")
 
 		span.End()
@@ -148,13 +154,20 @@ func (fr *FrontRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			matchedPrefixes = append(matchedPrefixes, prefix)
 		}
 	}
+
 	if len(matchedPrefixes) > 0 {
 		prefix := longest(matchedPrefixes)
 		router := fr.router[prefix]
 		r, _ := tag.New(req.Context(), tag.Upsert(opencensus.KeyArea, router.area))
 		req = req.WithContext(r)
 
-		req.URL, _ = url.Parse(path[len(prefix):])
+		var err error
+		req.URL, err = url.Parse(path[len(prefix):])
+		if err != nil {
+			w.WriteHeader(404)
+			return
+		}
+
 		req.URL.Path = "/" + strings.TrimLeft(req.URL.Path, "/")
 
 		span.End()

--- a/framework/prefixrouter/front_router_test.go
+++ b/framework/prefixrouter/front_router_test.go
@@ -13,27 +13,27 @@ func TestFrontRouter(t *testing.T) {
 	var fr = NewFrontRouter()
 
 	fr.Add("/prefix1", routerHandler{handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("Prefix 1"))
+		_, _ = w.Write([]byte("Prefix 1"))
 	})})
 
 	fr.Add("/prefix2", routerHandler{handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("Prefix 2"))
+		_, _ = w.Write([]byte("Prefix 2"))
 	})})
 
 	fr.Add("/prefix22", routerHandler{handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("Prefix 22"))
+		_, _ = w.Write([]byte("Prefix 22"))
 	})})
 
 	fr.Add("test.com/prefix1", routerHandler{handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("Host1, Prefix 1"))
+		_, _ = w.Write([]byte("Host1, Prefix 1"))
 	})})
 
 	fr.Add("test.com/prefix11", routerHandler{handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("Host1, Prefix 11"))
+		_, _ = w.Write([]byte("Host1, Prefix 11"))
 	})})
 
 	fr.SetFinalFallbackHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("Default"))
+		_, _ = w.Write([]byte("Default"))
 	}))
 
 	t.Run("Request Routing", func(t *testing.T) {
@@ -112,13 +112,38 @@ func TestFrontRouter(t *testing.T) {
 		})
 
 		t.Run("Should use 404 if no default is set", func(t *testing.T) {
-			fr = NewFrontRouter()
+			emptyFR := NewFrontRouter()
 			recorder := httptest.NewRecorder()
 			request := httptest.NewRequest("GET", "/prefix1/test", nil)
+			emptyFR.ServeHTTP(recorder, request)
+
+			assert.Equal(t, recorder.Result().StatusCode, 404)
+			body, err := ioutil.ReadAll(recorder.Result().Body)
+			assert.NoError(t, err)
+			assert.Equal(t, body, []byte(``))
+		})
+
+		t.Run("Malformed url should lead to 404", func(t *testing.T) {
+			// only path
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest("GET", "/prefix1", nil)
+			request.RequestURI = "/prefix1%20HTTP%2F1.1%0D%0ASomeheader:%20value%0D%0A%0D%0A/test"
 			fr.ServeHTTP(recorder, request)
 
 			assert.Equal(t, recorder.Result().StatusCode, 404)
 			body, err := ioutil.ReadAll(recorder.Result().Body)
+			assert.NoError(t, err)
+			assert.Equal(t, body, []byte(``))
+
+			// host + path
+			recorder = httptest.NewRecorder()
+			request = httptest.NewRequest("GET", "/prefix1", nil)
+			request.Host = "test.com"
+			request.RequestURI = "/prefix1%20HTTP%2F1.1%0D%0ASomeheader:%20value%0D%0A%0D%0A/test"
+			fr.ServeHTTP(recorder, request)
+
+			assert.Equal(t, recorder.Result().StatusCode, 404)
+			body, err = ioutil.ReadAll(recorder.Result().Body)
 			assert.NoError(t, err)
 			assert.Equal(t, body, []byte(``))
 		})


### PR DESCRIPTION
The front router truncates the prefix in the path and creates a new request. To do this the `url.Parse` function is used. If an invalid path is processed a nil pointer occurs.

This PR changes the behavior and returns a 404 page if an invalid path is used in the request.

fixes #198