### PR TITLE
core/auth: update to recent go-oidc v3, allow oidc issuer URL override

### DIFF
--- a/core/auth/Readme.md
+++ b/core/auth/Readme.md
@@ -1,8 +1,7 @@
 # Auth
 
 ## Design
-
-In general all identifying broker are able to be specified more than once, and at any point there can be zero to many identities available.
+In general, all identifying brokers are able to be specified more than once, and at any point, there can be zero to many identities available.
 
 ### Identity
 The `auth.Identity` is the minimum available information about an identified request/context situation.
@@ -13,15 +12,14 @@ The WebIdentifier primarily identifies incoming `web.Request`s.
 This could be done by means of inspecting the session, request data (auth header), etc.
 
 ### WebAuthenticator
-WebIdentifier who implement the authenticator interface are able to trigger an authentication.
-This can be a redirect to an external page, setting http headers or presenting a login form.
+WebIdentifier who implements the authenticator interface is able to trigger authentication.
+This can be a redirect to an external page, setting HTTP headers, or presenting a login form.
 
 ### WebLogouter
-Once a logout is triggered all identifier who implement either one of the logout methods are called.
-The WebLogouter will destroy session data etc., while the WebLogouterWithRedirect can return a redirect (e.g. to an oidc server).
+Once a logout has triggered all identifiers who implement either one of the logout methods are called.
+The WebLogouter will destroy session data etc., while the WebLogouterWithRedirect can return a redirect (e.g. to an OpenID Connect server).
 
 Multiple redirects are handled automagically.
 
 ## Debug
-
 In debug mode (`core.auth.web.debugController`, default to `flamingo.debug.mode`) there is http://localhost:3322/core/auth/debug for debugging.

--- a/core/auth/mock/identity.go
+++ b/core/auth/mock/identity.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"encoding/json"
 
-	"github.com/coreos/go-oidc"
+	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
 )
 

--- a/core/auth/oauth/module.go
+++ b/core/auth/oauth/module.go
@@ -45,6 +45,7 @@ core: auth: {
 			userInfo: [...string]
 		}
 		enableEndSessionEndpoint: bool | *true
+		overrideIssuerURL: string | *""
 	}
 }
 `

--- a/core/auth/oauth/module_test.go
+++ b/core/auth/oauth/module_test.go
@@ -1,0 +1,14 @@
+package oauth_test
+
+import (
+	"testing"
+
+	"flamingo.me/flamingo/v3/core/auth/oauth"
+	"flamingo.me/flamingo/v3/framework/config"
+)
+
+func TestModule_Configure(t *testing.T) {
+	if err := config.TryModules(config.Map{"core.auth.web.debugController": false}, new(oauth.Module)); err != nil {
+		t.Error(err)
+	}
+}

--- a/core/auth/oauth/oidc.go
+++ b/core/auth/oauth/oidc.go
@@ -102,7 +102,7 @@ func oidcFactory(cfg config.Map) (auth.RequestIdentifier, error) {
 
 	ctx := context.Background()
 	if oidcConfig.OverrideIssuerURL != "" {
-		oidc.InsecureIssuerURLContext(ctx, oidcConfig.OverrideIssuerURL)
+		ctx = oidc.InsecureIssuerURLContext(ctx, oidcConfig.OverrideIssuerURL)
 	}
 
 	provider, err := oidc.NewProvider(ctx, oidcConfig.Endpoint)

--- a/core/auth/oauth/oidc.go
+++ b/core/auth/oauth/oidc.go
@@ -292,7 +292,6 @@ func (i *openIDIdentifier) config(request *web.Request) *oauth2.Config {
 	return &oauth2Config
 }
 
-
 // StateEntry stores entries of recent states during login (oidc states)
 type StateEntry struct {
 	State string

--- a/core/auth/oauth/oidc.go
+++ b/core/auth/oauth/oidc.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/coreos/go-oidc"
+	"github.com/coreos/go-oidc/v3/oidc"
 	uuid "github.com/satori/go.uuid"
 	"golang.org/x/oauth2"
 
@@ -73,7 +73,8 @@ type (
 			IDToken     map[string]string `json:"idToken"`
 			AccessToken map[string]string `json:"accessToken"`
 		} `json:"claims"`
-		EnableEndSessionEndpoint bool `json:"enableEndSessionEndpoint"`
+		EnableEndSessionEndpoint bool   `json:"enableEndSessionEndpoint"`
+		OverrideIssuerURL        string `json:"overrideIssuerURL"`
 	}
 )
 
@@ -99,7 +100,12 @@ func oidcFactory(cfg config.Map) (auth.RequestIdentifier, error) {
 		return nil, err
 	}
 
-	provider, err := oidc.NewProvider(context.Background(), oidcConfig.Endpoint)
+	ctx := context.Background()
+	if oidcConfig.OverrideIssuerURL != "" {
+		oidc.InsecureIssuerURLContext(ctx, oidcConfig.OverrideIssuerURL)
+	}
+
+	provider, err := oidc.NewProvider(ctx, oidcConfig.Endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -286,6 +292,7 @@ func (i *openIDIdentifier) config(request *web.Request) *oauth2.Config {
 	return &oauth2Config
 }
 
+// StateEntry stores information about the state parameter used during authentication at a specific time
 type StateEntry struct {
 	State string
 	TS    time.Time
@@ -311,7 +318,7 @@ func (i *openIDIdentifier) validateSessionCode(request *web.Request, code string
 	if !ok {
 		return false
 	}
-	newstates := make([]StateEntry, 0, len(states))
+	newStates := make([]StateEntry, 0, len(states))
 	validated := false
 	for _, state := range states {
 		if state.TS.Add(stateTimeout).Before(now()) {
@@ -321,9 +328,9 @@ func (i *openIDIdentifier) validateSessionCode(request *web.Request, code string
 			validated = true
 			continue
 		}
-		newstates = append(newstates, state)
+		newStates = append(newStates, state)
 	}
-	request.Session().Store(i.sessionCode(sessionStatesKey), newstates)
+	request.Session().Store(i.sessionCode(sessionStatesKey), newStates)
 	return validated
 }
 

--- a/core/oauth/application/authmanager.go
+++ b/core/oauth/application/authmanager.go
@@ -16,7 +16,7 @@ import (
 	"flamingo.me/flamingo/v3/framework/config"
 	"flamingo.me/flamingo/v3/framework/flamingo"
 	"flamingo.me/flamingo/v3/framework/web"
-	"github.com/coreos/go-oidc"
+	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
 )
 

--- a/core/oauth/domain/mapping.go
+++ b/core/oauth/domain/mapping.go
@@ -6,7 +6,7 @@ import (
 
 	"flamingo.me/flamingo/v3/framework/config"
 	"flamingo.me/flamingo/v3/framework/web"
-	"github.com/coreos/go-oidc"
+	"github.com/coreos/go-oidc/v3/oidc"
 )
 
 type (

--- a/core/oauth/domain/user.go
+++ b/core/oauth/domain/user.go
@@ -5,7 +5,7 @@ import (
 
 	"flamingo.me/flamingo/v3/core/security/domain"
 	"flamingo.me/flamingo/v3/framework/web"
-	oidc "github.com/coreos/go-oidc"
+	oidc "github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
 )
 

--- a/core/oauth/interfaces/legacyIdentifier.go
+++ b/core/oauth/interfaces/legacyIdentifier.go
@@ -10,7 +10,7 @@ import (
 	"flamingo.me/flamingo/v3/core/oauth/application"
 	"flamingo.me/flamingo/v3/core/oauth/domain"
 	"flamingo.me/flamingo/v3/framework/web"
-	"github.com/coreos/go-oidc"
+	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	cuelang.org/go v0.0.15
 	flamingo.me/dingo v0.2.9
 	github.com/boj/redistore v0.0.0-20180917114910-cd5dcc76aeff
-	github.com/coreos/go-oidc v2.0.0+incompatible
+	github.com/coreos/go-oidc/v3 v3.1.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang-jwt/jwt/v4 v4.1.0
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
@@ -45,5 +45,4 @@ require (
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f
 	google.golang.org/api v0.56.0 // indirect
-	gopkg.in/square/go-jose.v2 v2.1.9 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/cockroachdb/apd/v2 v2.0.1 h1:y1Rh3tEU89D+7Tgbw+lp52T6p/GJLpDmNvr10UWq
 github.com/cockroachdb/apd/v2 v2.0.1/go.mod h1:DDxRlzC2lo3/vSlmSoS7JkqbbrARPuFOGr0B9pvN3Gw=
 github.com/coreos/go-oidc v2.0.0+incompatible h1:+RStIopZ8wooMx+Vs5Bt8zMXxV1ABl5LbakNExNmZIg=
 github.com/coreos/go-oidc v2.0.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
+github.com/coreos/go-oidc/v3 v3.1.0 h1:6avEvcdvTa1qYsOZ6I5PRkSYHzpTNWgKYmaJfaYbrRw=
+github.com/coreos/go-oidc/v3 v3.1.0/go.mod h1:rEJ/idjfUyfkBit1eI1fvyr+64/g9dcKpAm8MJMesvo=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -487,6 +489,7 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200505041828-1ed23360d12c/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200506145744-7e3656a0809f/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
@@ -804,6 +807,8 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/square/go-jose.v2 v2.1.9 h1:YCFbL5T2gbmC2sMG12s1x2PAlTK5TZNte3hjZEIcCAg=
 gopkg.in/square/go-jose.v2 v2.1.9/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/square/go-jose.v2 v2.5.1 h1:7odma5RETjNHWJnR32wx8t+Io4djHE1PqxCFx3iiZ2w=
+gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
According to the OpenID Connect specs, the /.well-known/openid-configuration should contain an `issuer` field that matches the URL used to fetch the configuration metadata:

> The issuer value returned MUST be identical to the Issuer URL that was directly used to retrieve the configuration information. This MUST also be identical to the iss Claim value in ID Tokens issued from this Issuer.

https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig

The OIDC solutions provided from Azure for example when using the Azure Active Directory B2C currently doesn't adhere to the OpenID Connect spec and returns a wrong issuer.

Since that's something they won't fix that fast (or maybe not even at all) we should introduce a configuration to support overriding the issuer URL.

https://github.com/MicrosoftDocs/azure-docs/issues/38427#issuecomment-555855086

Changes in go-oidc: https://github.com/coreos/go-oidc/compare/v2.0.0...v3.1.0