### PR TITLE
feat(session): add timeout for redis connection

### DIFF
--- a/framework/flamingo/ReadmeSession.md
+++ b/framework/flamingo/ReadmeSession.md
@@ -41,6 +41,7 @@ flamingo.session.redis.database: 0                                    # database
 flamingo.session.redis.idle.connections: 10                           # maximum number of idle connections
 flamingo.session.redis.tls: true                                      # enable tls for connections
 flamingo.session.redis.clusterMode: false                             # for redis servers running in cluster mode
+flamingo.session.redis.timeout: 5s                                    # timeout for establishing the connection (as time.Duration string)
 ```
 
 ##### custom

--- a/framework/flamingo/sessions_test.go
+++ b/framework/flamingo/sessions_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"flamingo.me/flamingo/v3/framework/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,6 +16,18 @@ type testData struct {
 	expectedRedisHost     string
 	expectedRedisPassword string
 	expectedRedisDatabase int
+}
+
+func TestModule_Configure(t *testing.T) {
+	t.Run("empty additional configuration", func(t *testing.T) {
+		if err := config.TryModules(nil, new(SessionModule)); err != nil {
+			t.Error(err)
+		}
+	})
+	t.Run("invalid redis timeout should lead to error", func(t *testing.T) {
+		err := config.TryModules(config.Map{"flamingo.session.redis.timeout": "foo"}, new(SessionModule))
+		assert.Error(t, err)
+	})
 }
 
 func TestGetRedisConnectionInformation(t *testing.T) {


### PR DESCRIPTION
The redis store is waiting internally on a ping response on creation. This feature adds a controllable timeout for it.