### PR TITLE
ci: add golangci-lint to pipeline

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,26 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.*
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.50
+          only-new-issues: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,12 +81,6 @@ jobs:
         run: |
           fmt=$(gofmt -l .)
           test -z $fmt || (echo "please run gofmt" ; echo $fmt ; exit 1)
-      - name: Go Staticcheck
-        run: go run honnef.co/go/tools/cmd/staticcheck@latest ./...
-      - name: Spelling
-        run: go run github.com/client9/misspell/cmd/misspell@v0.3.4 -error .
-      - name: Ineffective assignments
-        run: go run github.com/gordonklaus/ineffassign@4cc7213 .
       - name: Goimports
         run: |
           go run golang.org/x/tools/cmd/goimports@latest -w .

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,146 @@
+# Options for analysis running.
+run:
+  concurrency: 4
+  timeout: 5m
+  tests: true
+  # vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  skip-dirs-use-default: true
+  modules-download-mode: readonly
+  allow-parallel-runners: false
+  go: '1.19'
+
+# output configuration options
+output:
+  # Format: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
+  #
+  # Multiple can be specified by separating them by comma, output can be provided
+  # for each of them by separating format name and path by colon symbol.
+  # Output path can be either `stdout`, `stderr` or path to the file to write to.
+  # Example: "checkstyle:report.json,colored-line-number"
+  #
+  # Default: colored-line-number
+  format: tab
+  print-issued-lines: true
+  print-linter-name: true
+  uniq-by-line: true
+  sort-results: true
+
+linters:
+  disable-all: true
+  enable:
+    - bidichk
+    - bodyclose
+    - containedctx
+    - contextcheck
+    - cyclop
+    - durationcheck
+    - errcheck
+    - errname
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - forbidigo
+    - forcetypeassert
+    - gocognit
+    - goconst
+    - gocritic
+    - goerr113
+    - gofmt
+    - gomnd
+    - gomoddirectives
+    - gosec
+    - gosimple
+    - govet
+    - grouper
+    - ineffassign
+    - makezero
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnil
+    - noctx
+    - nolintlint
+    - nosprintfhostport
+    - paralleltest
+    - prealloc
+    - predeclared
+    - revive
+    - staticcheck
+    - tenv
+    - testpackage
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - varnamelen
+    - wrapcheck
+    - wsl
+
+issues:
+  new: false
+  fix: false
+  new-from-rev: cd180e1126ae5ae518366f749166750e67bc3194
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - containedctx
+        - forcetypeassert
+        - goconst
+        - goerr113
+        - varnamelen
+        - wrapcheck
+
+severity:
+  default-severity: blocker
+  rules: # code-climate format from gitlab supports: info, minor, major, critical, or blocker
+    - severity: critical
+      linters:
+        - gosec
+    - severity: major
+      linters:
+        - goerr113
+        - prealloc
+        - wrapcheck
+    - severity: minor
+      linters:
+        - cyclop
+        - decorder
+        - errname
+        - goconst
+        - gocognit
+        - predeclared
+        - testpackage
+        - tparallel
+        - usestdlibvars
+        - varnamelen
+    - severity: info
+      linters:
+        - paralleltest
+        - thelper
+        - wsl
+
+linters-settings:
+  gomnd:
+    ignored-functions:
+      - context.WithTimeout
+  nolintlint:
+    require-specific: true
+    require-explanation: true
+  revive:
+    rules:
+      - name: var-naming
+        disabled: true
+  varnamelen:
+    max-distance: 10
+    ignore-type-assert-ok: true
+    ignore-map-index-ok: true
+    ignore-chan-recv-ok: true
+    ignore-names:
+      - err
+      - id
+    ignore-decls:
+      - i int

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,7 +83,7 @@ linters:
 issues:
   new: false
   fix: false
-  new-from-rev: cd180e1126ae5ae518366f749166750e67bc3194
+  new-from-rev: 2399c75fbd6c738c4cddf38a3ad7f5f97367e5ec
   exclude-rules:
     - path: _test\.go
       linters:


### PR DESCRIPTION
Add linter with discussed rules. Only newly introduced issues should be blocking the pipeline