### PR TITLE
feat(core/zap): Make caller encoder configurable, add additional one

### DIFF
--- a/core/zap/caller_encoder.go
+++ b/core/zap/caller_encoder.go
@@ -1,0 +1,31 @@
+package zap
+
+import (
+	"os"
+	"runtime"
+	"strings"
+
+	"go.uber.org/zap/zapcore"
+)
+
+func short(file string) string {
+	parts := strings.Split(file, string(os.PathSeparator))
+
+	file = ""
+
+	for i, part := range parts {
+		if i == len(parts)-1 || len(part) == 0 {
+			file += part
+		} else if i == len(parts)-2 {
+			file += part + "/"
+		} else {
+			file += string(part[0]) + "/"
+		}
+	}
+
+	return file
+}
+
+func smartCallerEncoder(caller zapcore.EntryCaller, enc zapcore.PrimitiveArrayEncoder) {
+	enc.AppendString(short(runtime.FuncForPC(caller.PC).Name()))
+}

--- a/core/zap/caller_encoder_test.go
+++ b/core/zap/caller_encoder_test.go
@@ -1,0 +1,12 @@
+package zap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShort(t *testing.T) {
+	assert.Equal(t, "", short(""))
+	assert.Equal(t, "a/bbb/ccc.ddd.eee", short("aaa/bbb/ccc.ddd.eee"))
+}

--- a/core/zap/module.go
+++ b/core/zap/module.go
@@ -2,6 +2,7 @@ package zap
 
 import (
 	"context"
+	"fmt"
 
 	"flamingo.me/dingo"
 	"flamingo.me/flamingo/v3/framework/config"
@@ -11,7 +12,7 @@ import (
 )
 
 type (
-	// Module for logrus logging
+	// Module for zap logging
 	Module struct {
 		area               string
 		json               bool
@@ -23,11 +24,18 @@ type (
 		samplingThereafter float64
 		fieldMap           map[string]string
 		logSession         bool
+		callerEncoder      zapcore.CallerEncoder
 	}
 
 	shutdownEventSubscriber struct {
 		logger flamingo.Logger
 	}
+)
+
+const (
+	ZapCallerEncoderShort = "short"
+	ZapCallerEncoderSmart = "smart"
+	ZapCallerEncoderFull  = "full"
 )
 
 var logLevels = map[string]zapcore.Level{
@@ -38,6 +46,12 @@ var logLevels = map[string]zapcore.Level{
 	"DPanic": zap.DPanicLevel,
 	"Panic":  zap.PanicLevel,
 	"Fatal":  zap.FatalLevel,
+}
+
+var callerEncoders = map[string]zapcore.CallerEncoder{
+	ZapCallerEncoderSmart: smartCallerEncoder,
+	ZapCallerEncoderFull:  zapcore.FullCallerEncoder,
+	ZapCallerEncoderShort: zapcore.ShortCallerEncoder,
 }
 
 // Inject dependencies
@@ -52,6 +66,7 @@ func (m *Module) Inject(config *struct {
 	SamplingThereafter float64    `inject:"config:core.zap.sampling.thereafter,optional"`
 	FieldMap           config.Map `inject:"config:core.zap.fieldmap,optional"`
 	LogSession         bool       `inject:"config:core.zap.logsession,optional"`
+	CallerEncoder      string     `inject:"config:core.zap.encoding.caller,optional"`
 }) {
 	m.area = config.Area
 	m.json = config.JSON
@@ -62,6 +77,12 @@ func (m *Module) Inject(config *struct {
 	m.samplingInitial = config.SamplingInitial
 	m.samplingThereafter = config.SamplingThereafter
 	m.logSession = config.LogSession
+	m.callerEncoder = callerEncoders[ZapCallerEncoderShort]
+
+	if encoder, ok := callerEncoders[config.CallerEncoder]; ok {
+		m.callerEncoder = encoder
+	}
+
 	if config.FieldMap != nil {
 		m.fieldMap = make(map[string]string, len(config.FieldMap))
 		for k, v := range config.FieldMap {
@@ -72,7 +93,7 @@ func (m *Module) Inject(config *struct {
 	}
 }
 
-// Configure the logrus logger as flamingo.Logger (in JSON mode kibana compatible)
+// Configure the zap logger as flamingo.Logger
 func (m *Module) Configure(injector *dingo.Injector) {
 	level, ok := logLevels[m.logLevel]
 	if !ok {
@@ -115,7 +136,7 @@ func (m *Module) Configure(injector *dingo.Injector) {
 			EncodeLevel:    encoder,
 			EncodeTime:     zapcore.ISO8601TimeEncoder,
 			EncodeDuration: zapcore.SecondsDurationEncoder,
-			EncodeCaller:   zapcore.ShortCallerEncoder,
+			EncodeCaller:   m.callerEncoder,
 			EncodeName:     zapcore.FullNameEncoder,
 		},
 		OutputPaths:      []string{"stderr"},
@@ -159,16 +180,28 @@ func (subscriber *shutdownEventSubscriber) Notify(_ context.Context, event flami
 // CueConfig Schema
 func (m *Module) CueConfig() string {
 	// language=cue
-	return `
-core zap: {
+	return fmt.Sprintf(`
+core: zap: {
+	json: bool | *false
+	colored: bool | *false
+	devmode: bool | *false
+	logsession: bool | *false
+	fieldmap: {
+		[string]: string
+	}
+	
 	loglevel: *"Debug" | "Info" | "Warn" | "Error" | "DPanic" | "Panic" | "Fatal"
 	sampling: {
 		enabled: bool | *true
 		initial: int | *100 
 		thereafter: int | *100
 	}
+	
+	encoding: {
+		caller: *"%s" | "%s" | "%s"
+	}
 }
-`
+`, ZapCallerEncoderShort, ZapCallerEncoderSmart, ZapCallerEncoderFull)
 }
 
 // FlamingoLegacyConfigAlias mapping


### PR DESCRIPTION
Currently, we use the short caller encoder to receive file names/positions from zap. Due to this shortness, we often aren'T able to find the actual file. Lets make it configurable and introduce additional caller encoders that give more insights without polluting the log too mutch.