### PR TITLE
fix(core/auth/oauth): Properly mark OIDC callback error handler as optional

### DIFF
--- a/core/auth/oauth/oidc.go
+++ b/core/auth/oauth/oidc.go
@@ -32,7 +32,7 @@ type (
 
 	// CallbackErrorHandler can be used to handle errors in the Callback e.g. to cover prompt=none cases
 	CallbackErrorHandler interface {
-		Handle(ctx context.Context, broker string, request *web.Request, errString string, errDetails string) web.Result
+		Handle(ctx context.Context, broker string, request *web.Request, originalReturnTo func(request *web.Request) *url.URL, errString string, errDetails string) web.Result
 	}
 
 	oidcIdentity struct {
@@ -188,7 +188,7 @@ func (i *openIDIdentifier) Inject(
 	eventRouter flamingo.EventRouter,
 	authCodeOptionerProvider authCodeOptionerProvider,
 	optionals *struct {
-		CallbackErrorHandler CallbackErrorHandler `inject:"optional"`
+		CallbackErrorHandler CallbackErrorHandler `inject:",optional"`
 	},
 ) {
 	i.responder = responder
@@ -423,7 +423,7 @@ func (i *openIDIdentifier) Callback(ctx context.Context, request *web.Request, r
 	if errString, err := request.Query1("error"); err == nil {
 		errDetails, _ := request.Query1("error_description")
 		if i.callbackErrorHandler != nil {
-			if result := i.callbackErrorHandler.Handle(ctx, i.broker, request, errString, errDetails); result != nil {
+			if result := i.callbackErrorHandler.Handle(ctx, i.broker, request, returnTo, errString, errDetails); result != nil {
 				return result
 			}
 		}

--- a/core/auth/oauth/oidc_test.go
+++ b/core/auth/oauth/oidc_test.go
@@ -41,7 +41,7 @@ type mockCallbackErrorHandler struct {
 	SuppliedErrorDescription string
 }
 
-func (m *mockCallbackErrorHandler) Handle(_ context.Context, _ string, _ *web.Request, err string, errDesc string) web.Result {
+func (m *mockCallbackErrorHandler) Handle(_ context.Context, _ string, _ *web.Request, _ func(request *web.Request) *url.URL, err string, errDesc string) web.Result {
 	m.Called = true
 	m.SuppliedError = err
 	m.SuppliedErrorDescription = errDesc


### PR DESCRIPTION
By mistake, the newly introduced interface was not properly declared as optional but rather looked for an instance that was annotated with the name `optional`.

During testing, I also realized that it would make sense to have the original return URL within the function. 
Since this interface was introduced with the release yesterday and was not working at all I'll flag this only as a fix.