### PR TITLE
feat(core/auth/oidc): Add support of `AuthCodeOption` in the token exchange during callback

### DIFF
--- a/core/auth/oauth/oidc.go
+++ b/core/auth/oauth/oidc.go
@@ -467,7 +467,15 @@ func (i *openIDIdentifier) Callback(ctx context.Context, request *web.Request, r
 		return i.responder.ServerError(err)
 	}
 
-	oauth2Token, err := oauthConfig.Exchange(ctx, code)
+	options := make([]oauth2.AuthCodeOption, 0, len(i.authcodeOptions))
+	for _, o := range i.authcodeOptions {
+		options = append(options, o.Options(ctx, i.Broker(), request)...)
+	}
+	for _, o := range i.authCodeOptionerProvider() {
+		options = append(options, o.Options(ctx, i.Broker(), request)...)
+	}
+
+	oauth2Token, err := oauthConfig.Exchange(ctx, code, options...)
 	if err != nil {
 		return i.responder.ServerError(err)
 	}

--- a/core/auth/oauth/oidc.go
+++ b/core/auth/oauth/oidc.go
@@ -468,11 +468,11 @@ func (i *openIDIdentifier) Callback(ctx context.Context, request *web.Request, r
 	}
 
 	options := make([]oauth2.AuthCodeOption, 0, len(i.authcodeOptions))
-	for _, o := range i.authcodeOptions {
-		options = append(options, o.Options(ctx, i.Broker(), request)...)
-	}
-	for _, o := range i.authCodeOptionerProvider() {
-		options = append(options, o.Options(ctx, i.Broker(), request)...)
+
+	if i.authCodeOptionerProvider != nil {
+		for _, o := range i.authCodeOptionerProvider() {
+			options = append(options, o.Options(ctx, i.Broker(), request)...)
+		}
 	}
 
 	oauth2Token, err := oauthConfig.Exchange(ctx, code, options...)

--- a/core/auth/oauth/oidc.go
+++ b/core/auth/oauth/oidc.go
@@ -467,7 +467,7 @@ func (i *openIDIdentifier) Callback(ctx context.Context, request *web.Request, r
 		return i.responder.ServerError(err)
 	}
 
-	options := make([]oauth2.AuthCodeOption, 0, len(i.authcodeOptions))
+	options := make([]oauth2.AuthCodeOption, 0)
 
 	if i.authCodeOptionerProvider != nil {
 		for _, o := range i.authCodeOptionerProvider() {


### PR DESCRIPTION
Currently, it is only possible to modify the authorization URL using the `AuthCodeOptioner` interface. Since the Exchange function also supports this pattern we should also pass the registered `AuthCodeOptioner` to it.

For example, both my authorization and my token retrieval endpoint need some custom URL param to work. Only the one for the auth endpoint would currently be possible.