### PR TITLE
fix(zap): only record log metrics when we actually log something

### DIFF
--- a/core/silentzap/logger.go
+++ b/core/silentzap/logger.go
@@ -161,6 +161,10 @@ func makeFieldMap(configFieldMap config.Map) map[string]string {
 }
 
 func (l *SilentLogger) record(level string) {
+	if !l.Core().Enabled(logLevels[level]) {
+		return
+	}
+
 	ctx, _ := tag.New(context.Background(), tag.Upsert(opencensus.KeyArea, l.configArea), tag.Upsert(keyLevel, level))
 	stats.Record(ctx, logCount.M(1))
 }

--- a/core/zap/logger.go
+++ b/core/zap/logger.go
@@ -70,6 +70,10 @@ func (l *Logger) WithContext(ctx context.Context) flamingo.Logger {
 }
 
 func (l *Logger) record(level string) {
+	if !l.Core().Enabled(logLevels[level]) {
+		return
+	}
+
 	ctx, _ := tag.New(context.Background(), tag.Upsert(opencensus.KeyArea, l.configArea), tag.Upsert(keyLevel, level))
 	stats.Record(ctx, logCount.M(1))
 }


### PR DESCRIPTION
Actually we count each call to the log functions even if the configured log level is higher