### PR TITLE
ci: force on latest go version & cleanup jobs

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -7,16 +7,14 @@ on:
 jobs:
   static-checks:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: [ '1.*' ]
     name: Static checks
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go }}
+          go-version: 1.x
+          check-latest: true
       - name: WriteGoList
         run: go list -json -m all > go.list
       - name: Nancy

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,12 +15,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: 1.*
       - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.x
+          check-latest: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.20', '1.*' ]
+        go: [ '1.20', '1.x' ]
     name: Tests
     steps:
       - uses: actions/checkout@v3
@@ -21,24 +21,19 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
-      - name: Get dependencies
-        run: go get -v -t -d ./...
+          check-latest: true
       - name: Test
         run: CGO_ENABLED=1 go test -race ./...
   coverage:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: [ '1.*' ]
     name: Coverage Report
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go }}
-      - name: Get dependencies
-        run: go get -v -t -d ./...
+          go-version: 1.x
+          check-latest: true
       - name: Test
         run: |
           CGO_ENABLED=1 go run gotest.tools/gotestsum@v1.7.0 --junitfile test.xml --format testname -- -coverprofile coverage.txt -race ./...
@@ -64,18 +59,14 @@ jobs:
           path: code-coverage-results.md
   static-checks:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: [ '1.*' ]
     name: Static checks
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go }}
-      - name: Get dependencies
-        run: go get -v -t -d ./...
+          go-version: 1.x
+          check-latest: true
       - name: Go Vet
         run: go vet ./...
       - name: Go Fmt

--- a/.github/workflows/semanticore.yml
+++ b/.github/workflows/semanticore.yml
@@ -7,9 +7,6 @@ on:
 jobs:
   semanticore:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: [ '1.*' ]
     name: Semanticore
     steps:
       - uses: actions/checkout@v3
@@ -18,7 +15,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go }}
+          go-version: 1.x
+          check-latest: true
       - name: Semanticore
         run: go run github.com/aoepeople/semanticore@v0
         env:


### PR DESCRIPTION
remove matrix strategy from jobs where we only check one go version