### PR TITLE
feat(oidc): Make state timeout duration configurable to support long taking sign in

### DIFF
--- a/core/auth/oauth/module.go
+++ b/core/auth/oauth/module.go
@@ -46,6 +46,7 @@ core: auth: {
 		}
 		enableEndSessionEndpoint: bool | *true
 		overrideIssuerURL: string | *""
+		stateLifeTime: string | *"30m"
 	}
 }
 `

--- a/core/auth/oauth/oidc.go
+++ b/core/auth/oauth/oidc.go
@@ -145,8 +145,9 @@ func oidcFactory(cfg config.Map) (auth.RequestIdentifier, error) {
 	stateTimeout := defaultStateTimeout
 
 	if oidcConfig.StateLifeTime != "" {
-		if duration, err := time.ParseDuration(oidcConfig.StateLifeTime); err == nil {
-			stateTimeout = duration
+		stateTimeout, err = time.ParseDuration(oidcConfig.StateLifeTime)
+		if err != nil {
+			panic("invalid value for oidc broker config stateLifeTime")
 		}
 	}
 

--- a/core/auth/oauth/oidc.go
+++ b/core/auth/oauth/oidc.go
@@ -143,6 +143,7 @@ func oidcFactory(cfg config.Map) (auth.RequestIdentifier, error) {
 	}
 
 	stateTimeout := defaultStateTimeout
+
 	if oidcConfig.StateLifeTime != "" {
 		if duration, err := time.ParseDuration(oidcConfig.StateLifeTime); err == nil {
 			stateTimeout = duration

--- a/core/auth/oauth/oidc_test.go
+++ b/core/auth/oauth/oidc_test.go
@@ -55,8 +55,8 @@ func (m *mockCallbackErrorHandler) Handle(_ context.Context, _ string, _ *web.Re
 var _ CallbackErrorHandler = &mockCallbackErrorHandler{}
 
 func TestParallelStateRaceConditions(t *testing.T) {
+	//nolint:paralleltest // time.Now lives in global var `now` running this parallel will cause race cond
 	t.Run("test states", func(t *testing.T) {
-		//nolint:paralleltest // time.Now lives in global var `now` running this parallel will cause race cond
 		identifier := &openIDIdentifier{
 			authCodeOptionerProvider: func() []AuthCodeOptioner { return nil },
 			oauth2Config:             &oauth2.Config{},
@@ -71,7 +71,7 @@ func TestParallelStateRaceConditions(t *testing.T) {
 		resp = identifier.Authenticate(context.Background(), web.CreateRequest(nil, session))
 		state2 := resp.(*web.URLRedirectResponse).URL.Query().Get("state")
 
-		request, err := http.NewRequest(http.MethodGet, "http://example.com/callback", nil)
+		request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/callback", nil)
 		assert.NoError(t, err)
 
 		request.URL.RawQuery = url.Values{"state": []string{"invalid-state"}}.Encode()
@@ -96,8 +96,6 @@ func TestParallelStateRaceConditions(t *testing.T) {
 	})
 
 	t.Run("test default time shift", func(t *testing.T) {
-		//nolint:paralleltest // time.Now lives in global var `now` running this parallel will cause race cond
-
 		identifier := &openIDIdentifier{
 			authCodeOptionerProvider: func() []AuthCodeOptioner { return nil },
 			oauth2Config:             &oauth2.Config{},
@@ -105,7 +103,7 @@ func TestParallelStateRaceConditions(t *testing.T) {
 			responder:                &web.Responder{},
 		}
 
-		request, err := http.NewRequest(http.MethodGet, "http://example.com/callback", nil)
+		request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/callback", nil)
 		assert.NoError(t, err)
 
 		session := web.EmptySession()
@@ -126,8 +124,6 @@ func TestParallelStateRaceConditions(t *testing.T) {
 	})
 
 	t.Run("test custom time shift", func(t *testing.T) {
-		//nolint:paralleltest // time.Now lives in global var `now` running this parallel will cause race cond
-
 		identifier := &openIDIdentifier{
 			authCodeOptionerProvider: func() []AuthCodeOptioner { return nil },
 			oauth2Config:             &oauth2.Config{},
@@ -135,7 +131,7 @@ func TestParallelStateRaceConditions(t *testing.T) {
 			responder:                &web.Responder{},
 		}
 
-		request, err := http.NewRequest(http.MethodGet, "http://example.com/callback", nil)
+		request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/callback", nil)
 		assert.NoError(t, err)
 
 		session := web.EmptySession()

--- a/core/auth/oauth/oidc_test.go
+++ b/core/auth/oauth/oidc_test.go
@@ -56,8 +56,7 @@ var _ CallbackErrorHandler = &mockCallbackErrorHandler{}
 
 func TestParallelStateRaceConditions(t *testing.T) {
 	t.Run("test states", func(t *testing.T) {
-		t.Parallel()
-
+		//nolint:paralleltest // time.Now lives in global var `now` running this parallel will cause race cond
 		identifier := &openIDIdentifier{
 			authCodeOptionerProvider: func() []AuthCodeOptioner { return nil },
 			oauth2Config:             &oauth2.Config{},
@@ -97,7 +96,7 @@ func TestParallelStateRaceConditions(t *testing.T) {
 	})
 
 	t.Run("test default time shift", func(t *testing.T) {
-		t.Parallel()
+		//nolint:paralleltest // time.Now lives in global var `now` running this parallel will cause race cond
 
 		identifier := &openIDIdentifier{
 			authCodeOptionerProvider: func() []AuthCodeOptioner { return nil },
@@ -127,7 +126,7 @@ func TestParallelStateRaceConditions(t *testing.T) {
 	})
 
 	t.Run("test custom time shift", func(t *testing.T) {
-		t.Parallel()
+		//nolint:paralleltest // time.Now lives in global var `now` running this parallel will cause race cond
 
 		identifier := &openIDIdentifier{
 			authCodeOptionerProvider: func() []AuthCodeOptioner { return nil },

--- a/core/auth/oauth/oidc_test.go
+++ b/core/auth/oauth/oidc_test.go
@@ -54,6 +54,7 @@ func (m *mockCallbackErrorHandler) Handle(_ context.Context, _ string, _ *web.Re
 
 var _ CallbackErrorHandler = &mockCallbackErrorHandler{}
 
+//nolint:paralleltest // time.Now lives in global var `now` running this parallel will cause race cond
 func TestParallelStateRaceConditions(t *testing.T) {
 	//nolint:paralleltest // time.Now lives in global var `now` running this parallel will cause race cond
 	t.Run("test states", func(t *testing.T) {
@@ -95,6 +96,7 @@ func TestParallelStateRaceConditions(t *testing.T) {
 		assert.EqualError(t, errResp.Error, "state mismatch")
 	})
 
+	//nolint:paralleltest // time.Now lives in global var `now` running this parallel will cause race cond
 	t.Run("test default time shift", func(t *testing.T) {
 		identifier := &openIDIdentifier{
 			authCodeOptionerProvider: func() []AuthCodeOptioner { return nil },
@@ -123,6 +125,7 @@ func TestParallelStateRaceConditions(t *testing.T) {
 		now = time.Now
 	})
 
+	//nolint:paralleltest // time.Now lives in global var `now` running this parallel will cause race cond
 	t.Run("test custom time shift", func(t *testing.T) {
 		identifier := &openIDIdentifier{
 			authCodeOptionerProvider: func() []AuthCodeOptioner { return nil },

--- a/core/auth/oauth/oidc_test.go
+++ b/core/auth/oauth/oidc_test.go
@@ -55,24 +55,26 @@ func (m *mockCallbackErrorHandler) Handle(_ context.Context, _ string, _ *web.Re
 var _ CallbackErrorHandler = &mockCallbackErrorHandler{}
 
 func TestParallelStateRaceConditions(t *testing.T) {
-	identifier := &openIDIdentifier{
-		authCodeOptionerProvider: func() []AuthCodeOptioner { return nil },
-		oauth2Config:             &oauth2.Config{},
-		reverseRouter:            new(mockRouter),
-		responder:                &web.Responder{},
-	}
-
-	session := web.EmptySession()
-
-	resp := identifier.Authenticate(context.Background(), web.CreateRequest(nil, session))
-	state1 := resp.(*web.URLRedirectResponse).URL.Query().Get("state")
-	resp = identifier.Authenticate(context.Background(), web.CreateRequest(nil, session))
-	state2 := resp.(*web.URLRedirectResponse).URL.Query().Get("state")
-
-	request, err := http.NewRequest(http.MethodGet, "http://example.com/callback", nil)
-	assert.NoError(t, err)
-
 	t.Run("test states", func(t *testing.T) {
+		t.Parallel()
+
+		identifier := &openIDIdentifier{
+			authCodeOptionerProvider: func() []AuthCodeOptioner { return nil },
+			oauth2Config:             &oauth2.Config{},
+			reverseRouter:            new(mockRouter),
+			responder:                &web.Responder{},
+		}
+
+		session := web.EmptySession()
+
+		resp := identifier.Authenticate(context.Background(), web.CreateRequest(nil, session))
+		state1 := resp.(*web.URLRedirectResponse).URL.Query().Get("state")
+		resp = identifier.Authenticate(context.Background(), web.CreateRequest(nil, session))
+		state2 := resp.(*web.URLRedirectResponse).URL.Query().Get("state")
+
+		request, err := http.NewRequest(http.MethodGet, "http://example.com/callback", nil)
+		assert.NoError(t, err)
+
 		request.URL.RawQuery = url.Values{"state": []string{"invalid-state"}}.Encode()
 		resp = identifier.Callback(context.Background(), web.CreateRequest(request, session), nil)
 		errResp := resp.(*web.ServerErrorResponse)
@@ -95,6 +97,20 @@ func TestParallelStateRaceConditions(t *testing.T) {
 	})
 
 	t.Run("test default time shift", func(t *testing.T) {
+		t.Parallel()
+
+		identifier := &openIDIdentifier{
+			authCodeOptionerProvider: func() []AuthCodeOptioner { return nil },
+			oauth2Config:             &oauth2.Config{},
+			reverseRouter:            new(mockRouter),
+			responder:                &web.Responder{},
+		}
+
+		request, err := http.NewRequest(http.MethodGet, "http://example.com/callback", nil)
+		assert.NoError(t, err)
+
+		session := web.EmptySession()
+
 		resp := identifier.Authenticate(context.Background(), web.CreateRequest(nil, session))
 		state1 := resp.(*web.URLRedirectResponse).URL.Query().Get("state")
 
@@ -111,6 +127,20 @@ func TestParallelStateRaceConditions(t *testing.T) {
 	})
 
 	t.Run("test custom time shift", func(t *testing.T) {
+		t.Parallel()
+
+		identifier := &openIDIdentifier{
+			authCodeOptionerProvider: func() []AuthCodeOptioner { return nil },
+			oauth2Config:             &oauth2.Config{},
+			reverseRouter:            new(mockRouter),
+			responder:                &web.Responder{},
+		}
+
+		request, err := http.NewRequest(http.MethodGet, "http://example.com/callback", nil)
+		assert.NoError(t, err)
+
+		session := web.EmptySession()
+
 		resp := identifier.Authenticate(context.Background(), web.CreateRequest(nil, session))
 		state1 := resp.(*web.URLRedirectResponse).URL.Query().Get("state")
 		oneHour := time.Hour
@@ -321,6 +351,8 @@ func TestOidcCallback(t *testing.T) {
 }
 
 func Test_openIDIdentifier_RefreshIdentity(t *testing.T) {
+	t.Parallel()
+
 	var identifier auth.RequestIdentifier = &openIDIdentifier{broker: "broker"}
 	session := web.EmptySession()
 	session.Store("core.auth.oidc.broker.sessiondata", sessionData{


### PR DESCRIPTION
By default we invalidate all state params that are older than 30min, this means if you spent 30min on the login page of the identity provider and then came back to flamingo you would be greeted by a lovely state mismatch error.

Reasons for spending such a long time at the OIDC provider could be for example creating a new account with various verification steps.

Introducing a config to support long-running login/registrations. If not specified we'll stick to 30min.