### PR TITLE
feat(auth/oidc): Use BadRequest response for state mismatches, enhance logging with context

### DIFF
--- a/core/auth/oauth/oidc.go
+++ b/core/auth/oauth/oidc.go
@@ -443,12 +443,12 @@ func (i *openIDIdentifier) Authenticate(ctx context.Context, request *web.Reques
 
 	authConfig, err := i.config(request)
 	if err != nil {
-		return i.responder.ServerError(err)
+		return i.responder.ServerErrorWithContext(ctx, err)
 	}
 
 	u, err := url.Parse(authConfig.AuthCodeURL(state, options...))
 	if err != nil {
-		return i.responder.ServerError(err)
+		return i.responder.ServerErrorWithContext(ctx, err)
 	}
 
 	return i.responder.URLRedirect(u)
@@ -464,25 +464,26 @@ func (i *openIDIdentifier) Callback(ctx context.Context, request *web.Request, r
 			}
 		}
 
-		return i.responder.ServerError(fmt.Errorf("OpenID Connect error: %q (%q)", errString, errDetails))
+		return i.responder.ServerErrorWithContext(ctx, fmt.Errorf("OpenID Connect error: %q (%q)", errString, errDetails))
 	}
 
 	queryState, err := request.Query1("state")
 	if err != nil {
-		return i.responder.ServerError(errors.New("no state in request"))
+		return i.responder.BadRequestWithContext(ctx, errors.New("no state in request"))
 	}
+
 	if !i.validateSessionCode(request, queryState) {
-		return i.responder.ServerError(errors.New("state mismatch"))
+		return i.responder.BadRequestWithContext(ctx, errors.New("state mismatch"))
 	}
 
 	code, err := request.Query1("code")
 	if err != nil {
-		return i.responder.ServerError(err)
+		return i.responder.BadRequestWithContext(ctx, fmt.Errorf("%w: code", err))
 	}
 
 	oauthConfig, err := i.config(request)
 	if err != nil {
-		return i.responder.ServerError(err)
+		return i.responder.ServerErrorWithContext(ctx, err)
 	}
 
 	options := make([]oauth2.AuthCodeOption, 0)
@@ -495,13 +496,13 @@ func (i *openIDIdentifier) Callback(ctx context.Context, request *web.Request, r
 
 	oauth2Token, err := oauthConfig.Exchange(ctx, code, options...)
 	if err != nil {
-		return i.responder.ServerError(err)
+		return i.responder.ServerErrorWithContext(ctx, err)
 	}
 
 	// Extract the ID Token from OAuth2 token.
 	rawIDToken, ok := oauth2Token.Extra("id_token").(string)
 	if !ok {
-		return i.responder.ServerError(errors.New("claim id_token missing"))
+		return i.responder.ServerErrorWithContext(ctx, errors.New("claim id_token missing"))
 	}
 
 	verifierConfig := &oidc.Config{ClientID: i.oauth2Config.ClientID}
@@ -513,7 +514,7 @@ func (i *openIDIdentifier) Callback(ctx context.Context, request *web.Request, r
 	// Parse and verify ID Token payload.
 	idToken, err := verifier.Verify(ctx, rawIDToken)
 	if err != nil {
-		return i.responder.ServerError(err)
+		return i.responder.ServerErrorWithContext(ctx, err)
 	}
 
 	var (
@@ -523,7 +524,7 @@ func (i *openIDIdentifier) Callback(ctx context.Context, request *web.Request, r
 	)
 
 	if err := idToken.Claims(&tempIDTokenClaims); err != nil {
-		return i.responder.ServerError(err)
+		return i.responder.ServerErrorWithContext(ctx, err)
 	}
 	for k, v := range i.oidcConfig.Claims.IDToken {
 		idTokenClaims[k] = tempIDTokenClaims[v]
@@ -561,7 +562,7 @@ func (i *openIDIdentifier) Callback(ctx context.Context, request *web.Request, r
 	identity, err := i.Identify(ctx, request)
 	if err != nil {
 		i.Logout(ctx, request)
-		return i.responder.ServerError(err)
+		return i.responder.ServerErrorWithContext(ctx, err)
 	}
 
 	i.eventRouter.Dispatch(ctx, &auth.WebLoginEvent{Broker: i.broker, Request: request, Identity: identity})

--- a/core/auth/oauth/oidc_test.go
+++ b/core/auth/oauth/oidc_test.go
@@ -83,12 +83,12 @@ func TestParallelStateRaceConditions(t *testing.T) {
 		request.URL.RawQuery = url.Values{"state": []string{state2}}.Encode()
 		resp = identifier.Callback(context.Background(), web.CreateRequest(request, session), nil)
 		errResp = resp.(*web.ServerErrorResponse)
-		assert.EqualError(t, errResp.Error, "query value not found")
+		assert.EqualError(t, errResp.Error, "query value not found: code")
 
 		request.URL.RawQuery = url.Values{"state": []string{state1}}.Encode()
 		resp = identifier.Callback(context.Background(), web.CreateRequest(request, session), nil)
 		errResp = resp.(*web.ServerErrorResponse)
-		assert.EqualError(t, errResp.Error, "query value not found")
+		assert.EqualError(t, errResp.Error, "query value not found: code")
 
 		request.URL.RawQuery = url.Values{"state": []string{state1}}.Encode()
 		resp = identifier.Callback(context.Background(), web.CreateRequest(request, session), nil)

--- a/core/requestlogger/logger_test.go
+++ b/core/requestlogger/logger_test.go
@@ -30,12 +30,13 @@ func TestLogger(t *testing.T) {
 	request.Request().Header.Set("Referer", "https://example.com/")
 
 	responder := new(web.Responder).Inject(&web.Router{}, flamingo.NullLogger{}, &struct {
-		Engine                flamingo.TemplateEngine "inject:\",optional\""
-		Debug                 bool                    "inject:\"config:flamingo.debug.mode\""
-		TemplateForbidden     string                  "inject:\"config:flamingo.template.err403\""
-		TemplateNotFound      string                  "inject:\"config:flamingo.template.err404\""
-		TemplateUnavailable   string                  "inject:\"config:flamingo.template.err503\""
-		TemplateErrorWithCode string                  "inject:\"config:flamingo.template.errWithCode\""
+		Engine                flamingo.TemplateEngine `inject:",optional"`
+		Debug                 bool                    `inject:"config:flamingo.debug.mode"`
+		TemplateBadRequest    string                  `inject:"config:flamingo.template.err400"`
+		TemplateForbidden     string                  `inject:"config:flamingo.template.err403"`
+		TemplateNotFound      string                  `inject:"config:flamingo.template.err404"`
+		TemplateUnavailable   string                  `inject:"config:flamingo.template.err503"`
+		TemplateErrorWithCode string                  `inject:"config:flamingo.template.errWithCode"`
 	}{})
 
 	tests := []struct {

--- a/framework/module.go
+++ b/framework/module.go
@@ -104,6 +104,7 @@ flamingo: {
 		path?: string
 	}
 	template: {
+		err400: string | *"error/400"
 		err403: string | *"error/403"
 		err404: string | *"error/404"
 		errWithCode: string | *"error/withCode"


### PR DESCRIPTION
Using HTTP status code `500` for all issues occurring during the OIDC flow might not be the best way. Therefore changing at least the errors that can occur during the callback e.g. tinkered/missing state param as HTTP status `400`.

Additionally extending the web responder with error funcs that also take the ctx to enhance the logging for better traceability.