### PR TITLE
Add version command to the default framework CLI commands

### DIFF
--- a/framework/flamingo/flamingo.go
+++ b/framework/flamingo/flamingo.go
@@ -38,6 +38,7 @@ func GetAppInfo() AppInfo {
 
 	if info, ok := debug.ReadBuildInfo(); ok {
 		appInfo.MainPackagePath = info.Main.Path
+
 		for _, module := range info.Deps {
 			if module.Path == "flamingo.me/flamingo/v3" {
 				appInfo.FlamingoVersion = module.Version
@@ -52,7 +53,6 @@ func GetAppInfo() AppInfo {
 	}
 
 	return appInfo
-
 }
 
 // PrintAppInfo prints application info to the writer

--- a/framework/flamingo/flamingo.go
+++ b/framework/flamingo/flamingo.go
@@ -22,7 +22,7 @@ func AppVersion() string {
 	// in case no version is set with ldflags check executable build info (git commit hash is embedded by Go by default)
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, setting := range info.Settings {
-			if setting.Key == vcsRevisionSettingKey {
+			if setting.Key == vcsRevisionSettingKey && len(setting.Value) > 8 {
 				return fmt.Sprintf("%s-%s", baseSemanticVersion, setting.Value[:8])
 			}
 		}

--- a/framework/flamingo/flamingo.go
+++ b/framework/flamingo/flamingo.go
@@ -2,31 +2,64 @@ package flamingo
 
 import (
 	"fmt"
+	"io"
+	"runtime"
 	"runtime/debug"
 )
 
-var appVersion = ""
+var appVersion = "develop"
 
 const (
-	baseSemanticVersion   = "v0.0.0"
 	vcsRevisionSettingKey = "vcs.revision"
+)
+
+type (
+	AppInfo struct {
+		AppVersion      string
+		VCSRevision     string
+		RuntimeVersion  string
+		MainPackagePath string
+		FlamingoVersion string
+	}
 )
 
 // AppVersion returns the application version
 // set this during build with `go build -ldflags "-X flamingo.me/flamingo/v3/framework/flamingo.appVersion=1.2.3"`.
 func AppVersion() string {
-	if appVersion != "" {
-		return appVersion
+	return appVersion
+}
+
+// GetAppInfo provides basic application information like runtime version, flamingo version etc.
+func GetAppInfo() AppInfo {
+	appInfo := AppInfo{
+		AppVersion:     AppVersion(),
+		RuntimeVersion: runtime.Version(),
 	}
 
-	// in case no version is set with ldflags check executable build info (git commit hash is embedded by Go by default)
 	if info, ok := debug.ReadBuildInfo(); ok {
+		appInfo.MainPackagePath = info.Main.Path
+		for _, module := range info.Deps {
+			if module.Path == "flamingo.me/flamingo/v3" {
+				appInfo.FlamingoVersion = module.Version
+			}
+		}
+
 		for _, setting := range info.Settings {
-			if setting.Key == vcsRevisionSettingKey && len(setting.Value) > 8 {
-				return fmt.Sprintf("%s-%s", baseSemanticVersion, setting.Value[:8])
+			if setting.Key == vcsRevisionSettingKey {
+				appInfo.VCSRevision = setting.Value
 			}
 		}
 	}
 
-	return baseSemanticVersion
+	return appInfo
+
+}
+
+// PrintAppInfo prints application info to the writer
+func PrintAppInfo(writer io.Writer, appInfo AppInfo) {
+	_, _ = fmt.Fprintf(writer, "%20s\t%s\n", "App version:", appInfo.AppVersion)
+	_, _ = fmt.Fprintf(writer, "%20s\t%s\n", "Go runtime version:", appInfo.RuntimeVersion)
+	_, _ = fmt.Fprintf(writer, "%20s\t%s\n", "VCS revision:", appInfo.VCSRevision)
+	_, _ = fmt.Fprintf(writer, "%20s\t%s\n", "Path:", appInfo.MainPackagePath)
+	_, _ = fmt.Fprintf(writer, "%20s\t%s\n", "Flamingo version:", appInfo.FlamingoVersion)
 }

--- a/framework/flamingo/flamingo.go
+++ b/framework/flamingo/flamingo.go
@@ -1,9 +1,32 @@
 package flamingo
 
-var appVersion = "develop"
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+var appVersion = ""
+
+const (
+	baseSemanticVersion   = "v0.0.0"
+	vcsRevisionSettingKey = "vcs.revision"
+)
 
 // AppVersion returns the application version
 // set this during build with `go build -ldflags "-X flamingo.me/flamingo/v3/framework/flamingo.appVersion=1.2.3"`.
 func AppVersion() string {
-	return appVersion
+	if appVersion != "" {
+		return appVersion
+	}
+
+	// in case no version is set with ldflags check executable build info (git commit hash is embedded by Go by default)
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == vcsRevisionSettingKey {
+				return fmt.Sprintf("%s-%s", baseSemanticVersion, setting.Value[:8])
+			}
+		}
+	}
+
+	return baseSemanticVersion
 }

--- a/framework/flamingo/flamingo_test.go
+++ b/framework/flamingo/flamingo_test.go
@@ -1,15 +1,19 @@
-package flamingo
+package flamingo_test
 
 import (
 	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"flamingo.me/flamingo/v3/framework/flamingo"
 )
 
 func TestPrintAppInfo(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
-		appInfo AppInfo
+		appInfo flamingo.AppInfo
 	}
 
 	tests := []struct {
@@ -20,7 +24,7 @@ func TestPrintAppInfo(t *testing.T) {
 		{
 			name: "",
 			args: args{
-				appInfo: AppInfo{
+				appInfo: flamingo.AppInfo{
 					AppVersion:      "v1.2.3",
 					VCSRevision:     "c9ce01204a18ff2f3e9ed999fbf7f3eb8e70b614",
 					RuntimeVersion:  "go1.23.3",
@@ -31,10 +35,13 @@ func TestPrintAppInfo(t *testing.T) {
 			wantWriter: "        App version:\tv1.2.3\n Go runtime version:\tgo1.23.3\n       VCS revision:\tc9ce01204a18ff2f3e9ed999fbf7f3eb8e70b614\n               Path:\tgo.aoe.com/whitelabel-airline/flamingo\n   Flamingo version:\tv3.11.0\n",
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			writer := &bytes.Buffer{}
-			PrintAppInfo(writer, tt.args.appInfo)
+			flamingo.PrintAppInfo(writer, tt.args.appInfo)
 			assert.Equalf(t, tt.wantWriter, writer.String(), "PrintAppInfo(%v, %v)", writer, tt.args.appInfo)
 		})
 	}

--- a/framework/flamingo/flamingo_test.go
+++ b/framework/flamingo/flamingo_test.go
@@ -1,0 +1,41 @@
+package flamingo
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintAppInfo(t *testing.T) {
+	type args struct {
+		appInfo AppInfo
+	}
+
+	tests := []struct {
+		name       string
+		args       args
+		wantWriter string
+	}{
+		{
+			name: "",
+			args: args{
+				appInfo: AppInfo{
+					AppVersion:      "v1.2.3",
+					VCSRevision:     "c9ce01204a18ff2f3e9ed999fbf7f3eb8e70b614",
+					RuntimeVersion:  "go1.23.3",
+					MainPackagePath: "go.aoe.com/whitelabel-airline/flamingo",
+					FlamingoVersion: "v3.11.0",
+				},
+			},
+			wantWriter: "        App version:\tv1.2.3\n Go runtime version:\tgo1.23.3\n       VCS revision:\tc9ce01204a18ff2f3e9ed999fbf7f3eb8e70b614\n               Path:\tgo.aoe.com/whitelabel-airline/flamingo\n   Flamingo version:\tv3.11.0\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writer := &bytes.Buffer{}
+			PrintAppInfo(writer, tt.args.appInfo)
+			assert.Equalf(t, tt.wantWriter, writer.String(), "PrintAppInfo(%v, %v)", writer, tt.args.appInfo)
+		})
+	}
+}

--- a/framework/flamingo/versioncmd.go
+++ b/framework/flamingo/versioncmd.go
@@ -1,8 +1,6 @@
 package flamingo
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -11,7 +9,7 @@ func VersionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Application version",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(AppVersion())
+			cmd.Println(AppVersion())
 		},
 	}
 }

--- a/framework/flamingo/versioncmd.go
+++ b/framework/flamingo/versioncmd.go
@@ -1,6 +1,8 @@
 package flamingo
 
 import (
+	"bytes"
+
 	"github.com/spf13/cobra"
 )
 
@@ -9,7 +11,12 @@ func VersionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Application version",
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Println(AppVersion())
+			var buffer bytes.Buffer
+
+			appInfo := GetAppInfo()
+			PrintAppInfo(&buffer, appInfo)
+
+			cmd.Println(buffer.String())
 		},
 	}
 }

--- a/framework/flamingo/versioncmd.go
+++ b/framework/flamingo/versioncmd.go
@@ -1,0 +1,17 @@
+package flamingo
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func VersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Application version",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(AppVersion())
+		},
+	}
+}

--- a/framework/module.go
+++ b/framework/module.go
@@ -43,6 +43,7 @@ func (*InitModule) Configure(injector *dingo.Injector) {
 	injector.BindMulti(new(cobra.Command)).ToProvider(web.HandlerCmd)
 	injector.BindMulti(new(cobra.Command)).ToProvider(config.ModulesCmd)
 	injector.BindMulti(new(cobra.Command)).ToProvider(config.Cmd)
+	injector.BindMulti(new(cobra.Command)).ToProvider(flamingo.VersionCmd)
 
 	web.BindRoutes(injector, new(routes))
 

--- a/framework/module_test.go
+++ b/framework/module_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"flamingo.me/dingo"
+
 	"flamingo.me/flamingo/v3/framework"
 )
 

--- a/framework/systemendpoint/application/server.go
+++ b/framework/systemendpoint/application/server.go
@@ -3,11 +3,8 @@ package application
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net"
 	"net/http"
-	"runtime"
-	"runtime/debug"
 	"sync"
 
 	"flamingo.me/flamingo/v3/framework/flamingo"
@@ -61,16 +58,8 @@ func (s *SystemServer) Start() {
 	}
 
 	serveMux.HandleFunc("/version", func(writer http.ResponseWriter, _ *http.Request) {
-		_, _ = fmt.Fprintf(writer, "version: %s\n", flamingo.AppVersion())
-		_, _ = fmt.Fprintf(writer, "go: %s\n", runtime.Version())
-		if info, ok := debug.ReadBuildInfo(); ok {
-			_, _ = fmt.Fprintf(writer, "path: %s\n", info.Path)
-			for _, module := range info.Deps {
-				if module.Path == "flamingo.me/flamingo/v3" {
-					_, _ = fmt.Fprintf(writer, "flamingo: %s\n", module.Version)
-				}
-			}
-		}
+		appInfo := flamingo.GetAppInfo()
+		flamingo.PrintAppInfo(writer, appInfo)
 	})
 
 	listener, err := net.Listen("tcp", s.serviceAddress)


### PR DESCRIPTION
This PR adds a version command to the default Flamingo CLI commands. It also refactors /version endpoint of the system_endpoint to use a function for printing different useful infos about application (application version set via ldflags, Git revision, version of the Go runtime etc.). The same function is used for the CLI command.

```
$ myapp version

        App version:	1.2.3
 Go runtime version:	go1.23.3
       VCS revision:	2c8efce6b95f0216be3834270022cd53bef45300
               Path:	go.aoe.com/whitelabel-airline/flamingo
   Flamingo version:	v3.11.0
```