### PR TITLE
chore: edit mockery and linter configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,7 @@ linters:
     - contextcheck
     - cyclop
     - durationcheck
+    - err113
     - errcheck
     - errname
     - errorlint
@@ -44,9 +45,7 @@ linters:
     - gocognit
     - goconst
     - gocritic
-    - goerr113
     - gofmt
-    - gomnd
     - gomoddirectives
     - gosec
     - gosimple
@@ -55,6 +54,7 @@ linters:
     - ineffassign
     - makezero
     - misspell
+    - mnd
     - nakedret
     - nestif
     - nilerr
@@ -90,12 +90,12 @@ issues:
         - containedctx
         - forcetypeassert
         - goconst
-        - goerr113
+        - err113
         - varnamelen
         - wrapcheck
 
 linters-settings:
-  gomnd:
+  mnd:
     ignored-functions:
       - context.WithTimeout
   nolintlint:

--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -1,5 +1,24 @@
-inpackage: false
-testonly: false
-with-expecter: true
-keeptree: true
-disable-version-string: true
+with-expecter: True
+disable-version-string: True
+dir: "{{.InterfaceDir}}/mocks"
+outpkg: "mocks"
+mockname: "{{.InterfaceName}}"
+filename: "{{.InterfaceName | snakecase}}.go"
+packages:
+  "flamingo.me/flamingo/v3/core/security/application":
+    interfaces:
+      SecurityService:
+  "flamingo.me/flamingo/v3/core/security/application/role":
+    interfaces:
+      Provider:
+      Service:
+  "flamingo.me/flamingo/v3/core/security/domain":
+    interfaces:
+      PermissionSet:
+      Role:
+  "flamingo.me/flamingo/v3/core/security/application/voter":
+    interfaces:
+      SecurityVoter:
+  "flamingo.me/flamingo/v3/core/security/interface/middleware":
+    interfaces:
+      RedirectURLMaker:

--- a/app.go
+++ b/app.go
@@ -26,6 +26,8 @@ import (
 	"flamingo.me/flamingo/v3/framework/web"
 )
 
+//go:generate go run github.com/vektra/mockery/v2@v2.50.0
+
 type (
 	// Application contains a main flamingo application
 	Application struct {

--- a/core/security/application/doc.go
+++ b/core/security/application/doc.go
@@ -1,3 +1,1 @@
 package application
-
-//go:generate go run github.com/vektra/mockery/v2@v2.49.1 --name=SecurityService --case=underscore

--- a/core/security/application/role/doc.go
+++ b/core/security/application/role/doc.go
@@ -1,3 +1,1 @@
 package role
-
-//go:generate go run github.com/vektra/mockery/v2@v2.49.1 --all --case=underscore

--- a/core/security/application/voter/doc.go
+++ b/core/security/application/voter/doc.go
@@ -1,3 +1,1 @@
 package voter
-
-//go:generate go run github.com/vektra/mockery/v2@v2.49.1 --all --case=underscore

--- a/core/security/domain/doc.go
+++ b/core/security/domain/doc.go
@@ -1,3 +1,1 @@
 package domain
-
-//go:generate go run github.com/vektra/mockery/v2@v2.49.1 --all --case=underscore

--- a/core/security/domain/mocks/permission_set.go
+++ b/core/security/domain/mocks/permission_set.go
@@ -17,7 +17,7 @@ func (_m *PermissionSet) EXPECT() *PermissionSet_Expecter {
 	return &PermissionSet_Expecter{mock: &_m.Mock}
 }
 
-// Permissions provides a mock function with given fields:
+// Permissions provides a mock function with no fields
 func (_m *PermissionSet) Permissions() []string {
 	ret := _m.Called()
 

--- a/core/security/domain/mocks/role.go
+++ b/core/security/domain/mocks/role.go
@@ -17,7 +17,7 @@ func (_m *Role) EXPECT() *Role_Expecter {
 	return &Role_Expecter{mock: &_m.Mock}
 }
 
-// Label provides a mock function with given fields:
+// Label provides a mock function with no fields
 func (_m *Role) Label() string {
 	ret := _m.Called()
 
@@ -62,7 +62,7 @@ func (_c *Role_Label_Call) RunAndReturn(run func() string) *Role_Label_Call {
 	return _c
 }
 
-// Permissions provides a mock function with given fields:
+// Permissions provides a mock function with no fields
 func (_m *Role) Permissions() []string {
 	ret := _m.Called()
 

--- a/core/security/interface/middleware/doc.go
+++ b/core/security/interface/middleware/doc.go
@@ -1,3 +1,1 @@
 package middleware
-
-//go:generate go run github.com/vektra/mockery/v2@v2.49.1 --all --case=underscore


### PR DESCRIPTION
1. Edited mockery configuration to use packages
2. Removed go:generate annotations scattered across the code
3. Edited linter config (replaces deprecated linter names with the new ones)