### PR TITLE
chore: edit description of sessions module

### DIFF
--- a/framework/flamingo/ReadmeSession.md
+++ b/framework/flamingo/ReadmeSession.md
@@ -30,7 +30,7 @@ Stores the sessions in the directory specified by the `flamingo.session.file` pa
 The files will be persisted across application restarts. 
 
 ##### redis
-Stores the session in an external instance of [redis](https://redis.io/). 
+Stores the session in an external instance of Redis-compatible cache ([Redis](https://redis.io/), [Valkey](https://valkey.io)). 
 Use the following parameters to configure the connection to redis. 
 
 ```yaml

--- a/framework/flamingo/healthcheck/redisSession.go
+++ b/framework/flamingo/healthcheck/redisSession.go
@@ -3,8 +3,9 @@ package healthcheck
 import (
 	"context"
 
-	"flamingo.me/flamingo/v3/core/healthcheck/domain/healthcheck"
 	"github.com/redis/go-redis/v9"
+
+	"flamingo.me/flamingo/v3/core/healthcheck/domain/healthcheck"
 )
 
 // RedisSession status check


### PR DESCRIPTION
Edit description of sessions module to mention that any Redis-compatible cache can be used