### PR TITLE
Add tests for event dispatch when running commands and graceful shutdown

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1,0 +1,250 @@
+package flamingo_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"flamingo.me/dingo"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"flamingo.me/flamingo/v3"
+	"flamingo.me/flamingo/v3/framework/cmd"
+	framework "flamingo.me/flamingo/v3/framework/flamingo"
+)
+
+type NotifyFunc func(ctx context.Context, event framework.Event)
+
+func (nf NotifyFunc) Notify(ctx context.Context, event framework.Event) {
+	nf(ctx, event)
+}
+
+func TestCmdEventsTriggeredProperly(t *testing.T) { //nolint:paralleltest // due to dingo.Singleton
+	assertStartupAndShutdownOnce := func(startupEventCount, shutdownEventCount int32) {
+		assert.Equal(t, int32(1), startupEventCount, "startupEventCount should be 1")
+		assert.Equal(t, int32(1), shutdownEventCount, "shutdownEventCount should be 1")
+	}
+
+	tests := []struct {
+		name string
+		args string
+		want func(startupEventCount, shutdownEventCount int32)
+	}{
+		{
+			name: "command with Run: both startup and shutdown events are triggered",
+			args: "test_cmd_run",
+			want: assertStartupAndShutdownOnce,
+		},
+		{
+			name: "command with RunE: both startup and shutdown events are triggered",
+			args: "test_cmd_run_e",
+			want: assertStartupAndShutdownOnce,
+		},
+	}
+
+	for _, tt := range tests { //nolint:paralleltest // due to dingo.Singleton
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				startupEventCount  atomic.Int32
+				shutdownEventCount atomic.Int32
+			)
+
+			modules := []dingo.Module{
+				dingo.ModuleFunc(func(injector *dingo.Injector) {
+					injector.BindMulti(new(cobra.Command)).ToInstance(&cobra.Command{
+						Use:   "test_cmd_run",
+						Short: "test_cmd_run",
+						Run: func(cmd *cobra.Command, args []string) {
+							t.Log("test_cmd_run executed")
+							assert.Equal(t, "test_cmd_run", cmd.Short)
+							assert.Empty(t, args)
+						},
+					})
+					injector.BindMulti(new(cobra.Command)).ToInstance(&cobra.Command{
+						Use:   "test_cmd_run_e",
+						Short: "test_cmd_run_e",
+						RunE: func(cmd *cobra.Command, args []string) error {
+							t.Log("test_cmd_run_e executed")
+							assert.Equal(t, "test_cmd_run_e", cmd.Short)
+							assert.Empty(t, args)
+
+							return nil
+						},
+					})
+				}),
+				dingo.ModuleFunc(func(injector *dingo.Injector) {
+					framework.BindEventSubscriber(injector).ToInstance(NotifyFunc(func(ctx context.Context, event framework.Event) {
+						switch event.(type) {
+						case *framework.StartupEvent:
+							startupEventCount.Add(1)
+						case *framework.ShutdownEvent:
+							shutdownEventCount.Add(1)
+						}
+					}))
+				}),
+			}
+
+			dingo.Singleton = dingo.NewSingletonScope()
+			dingo.ChildSingleton = dingo.NewChildSingletonScope()
+
+			app, err := flamingo.NewApplication(modules,
+				flamingo.WithArgs(tt.args),
+			)
+			require.NoError(t, err)
+
+			err = app.Run()
+			require.NoError(t, err)
+		})
+	}
+}
+
+func buildSignalSender(t *testing.T) func() {
+	t.Helper()
+
+	return func() {
+		pid := os.Getpid()
+		process, err := os.FindProcess(pid)
+		require.NoError(t, err)
+
+		err = process.Signal(os.Interrupt)
+		require.NoError(t, err)
+	}
+}
+
+func TestGracefulShutdown(t *testing.T) { //nolint:paralleltest // due to dingo.Singleton
+	assertShutdownOnce := func(shutdownEventCount int32) {
+		assert.Equal(t, int32(1), shutdownEventCount, "shutdownEventCount should be 1")
+	}
+
+	tests := []struct {
+		name                string
+		args                string
+		onServerStartup     func()
+		onShutdown          func()
+		insideCommandRun    func(cmd *cobra.Command, args []string)
+		insideCommandRunE   func(cmd *cobra.Command, args []string) error
+		wantErr             assert.ErrorAssertionFunc
+		assertShutdownCount func(shutdownEventCount int32)
+	}{
+		{
+			name:                "serve command interrupted by SIGINT triggers graceful shutdown",
+			args:                "serve",
+			onServerStartup:     sync.OnceFunc(buildSignalSender(t)),
+			onShutdown:          func() {},
+			wantErr:             assert.NoError,
+			assertShutdownCount: assertShutdownOnce,
+		},
+		{
+			name: "custom Run command interrupted by SIGINT triggers graceful shutdown",
+			args: "test_cmd_run",
+			insideCommandRun: func(cmd *cobra.Command, args []string) {
+				buildSignalSender(t)()
+			},
+			onShutdown:          func() {},
+			wantErr:             assert.NoError,
+			assertShutdownCount: assertShutdownOnce,
+		},
+		{
+			name: "custom RunE command interrupted by SIGINT triggers graceful shutdown",
+			args: "test_cmd_run_e",
+			insideCommandRunE: func(cmd *cobra.Command, args []string) error {
+				buildSignalSender(t)()
+
+				return nil
+			},
+			onShutdown:          func() {},
+			wantErr:             assert.NoError,
+			assertShutdownCount: assertShutdownOnce,
+		},
+		{
+			name: "graceful shutdown interrupted by SIGINT forces hard shutdown",
+			args: "test_cmd_run",
+			insideCommandRun: func(cmd *cobra.Command, args []string) {
+				send := buildSignalSender(t)
+				send()
+				time.Sleep(time.Millisecond)
+				send()
+			},
+			onShutdown: sync.OnceFunc(func() {
+				// artificial delay, so that second interrupt could arrive
+				time.Sleep(time.Second)
+			}),
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorIs(t, err, cmd.ErrGracefulShutdown)
+			},
+			assertShutdownCount: assertShutdownOnce,
+		},
+
+		// TODO: use testing/synctest for this once it is not experimental
+		{
+			name: "graceful shutdown timed out forces hard shutdown",
+			args: "test_cmd_run",
+			insideCommandRun: func(cmd *cobra.Command, args []string) {
+				send := buildSignalSender(t)
+				send()
+			},
+			onShutdown: sync.OnceFunc(func() {
+				time.Sleep(35 * time.Second)
+			}),
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorIs(t, err, cmd.ErrGracefulShutdown)
+			},
+			assertShutdownCount: assertShutdownOnce,
+		},
+	}
+
+	for _, tt := range tests { //nolint:paralleltest // due to dingo.Singleton
+		t.Run(tt.name, func(t *testing.T) {
+			var shutdownEventCount atomic.Int32
+
+			modules := []dingo.Module{
+				dingo.ModuleFunc(func(injector *dingo.Injector) {
+					injector.BindMulti(new(cobra.Command)).ToInstance(&cobra.Command{
+						Use:   "test_cmd_run",
+						Short: "test_cmd_run",
+						Run:   tt.insideCommandRun,
+					})
+					injector.BindMulti(new(cobra.Command)).ToInstance(&cobra.Command{
+						Use:   "test_cmd_run_e",
+						Short: "test_cmd_run_e",
+						RunE:  tt.insideCommandRunE,
+					})
+				}),
+				dingo.ModuleFunc(func(injector *dingo.Injector) {
+					framework.
+						BindEventSubscriber(injector).
+						ToInstance(
+							NotifyFunc(func(ctx context.Context, event framework.Event) {
+								switch ev := event.(type) {
+								case *framework.ServerStartEvent:
+									if _, err := net.Dial("tcp", fmt.Sprintf(":%s", ev.Port)); err != nil {
+										t.Fatalf("failed to connect to server")
+									}
+
+									tt.onServerStartup()
+								case *framework.ShutdownEvent:
+									shutdownEventCount.Add(1)
+									tt.onShutdown()
+								}
+							}))
+				}),
+			}
+
+			dingo.Singleton = dingo.NewSingletonScope()
+			dingo.ChildSingleton = dingo.NewChildSingletonScope()
+
+			app, err := flamingo.NewApplication(modules, flamingo.WithArgs(tt.args))
+			require.NoError(t, err)
+
+			err = app.Run()
+			tt.wantErr(t, err)
+		})
+	}
+}

--- a/framework/cmd/module.go
+++ b/framework/cmd/module.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -10,15 +11,14 @@ import (
 	"syscall"
 	"time"
 
-	"flamingo.me/dingo"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"golang.org/x/sync/errgroup"
+
+	"flamingo.me/dingo"
 
 	"flamingo.me/flamingo/v3/framework/flamingo"
 )
-
-var once = sync.Once{}
-var shutdownOnce = sync.Once{}
 
 type (
 	eventRouterProvider func() flamingo.EventRouter
@@ -28,65 +28,91 @@ type (
 	Module struct{}
 )
 
+var (
+	// ErrCmdRun is returned when an error occurs during CLI command execution
+	ErrCmdRun = errors.New("command execution error")
+
+	// ErrGracefulShutdown is returned when graceful shutdown of the application cannot finish cleanly due to timeout or another signal
+	ErrGracefulShutdown = errors.New("graceful shutdown error")
+
+	signals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+)
+
 // Configure DI
 func (m *Module) Configure(injector *dingo.Injector) {
-	injector.Bind(new(cobra.Command)).AnnotatedWith("flamingo").ToProvider(
-		func(
-			commands []*cobra.Command,
-			eventRouterProvider eventRouterProvider,
-			logger flamingo.Logger,
-			flagSetProvider flagSetProvider,
-			config *struct {
-				Name string `inject:"config:flamingo.cmd.name"`
-			}) *cobra.Command {
-			signals := make(chan os.Signal, 1)
-			shutdownComplete := make(chan struct{}, 1)
-			signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	injector.Bind(new(cobra.Command)).
+		AnnotatedWith("flamingo").
+		ToProvider(RootCommandProvider).
+		In(dingo.Singleton)
+}
 
-			once.Do(func() {
-				go func() {
-					<-signals
-					// shutdown by signal for infinite running commands (e.g. serve command)
-					shutdownOnce.Do(func() {
-						shutdown(eventRouterProvider(), signals, shutdownComplete, logger)
-						<-shutdownComplete
-					})
-				}()
-			})
+// RootCommandProvider configures root cobra command to be used by the framework
+func RootCommandProvider(
+	commands []*cobra.Command,
+	eventRouterProvider eventRouterProvider,
+	logger flamingo.Logger,
+	flagSetProvider flagSetProvider,
+	config *struct {
+		Name string `inject:"config:flamingo.cmd.name"`
+	},
+) *cobra.Command {
+	var (
+		// declaring global context.CancelFunc and error to be used from both PersistentPreRun and PersistentPostRunE
+		stop             context.CancelFunc
+		err              error
+		execShutdownOnce = sync.OnceFunc(func() {
+			err = shutdown(logger, eventRouterProvider())
+		})
+	)
 
-			rootCmd := &cobra.Command{
-				Use:              config.Name,
-				Short:            "Flamingo " + config.Name,
-				TraverseChildren: true,
-				PersistentPostRunE: func(*cobra.Command, []string) error {
-					// shutdown through command that is finite (e.g. help command)
-					shutdownOnce.Do(func() {
-						shutdown(eventRouterProvider(), signals, shutdownComplete, logger)
-						<-shutdownComplete
-					})
+	rootCmd := &cobra.Command{
+		Use:              config.Name,
+		Short:            "Flamingo " + config.Name,
+		TraverseChildren: true,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			var ctx context.Context
+			ctx, stop = signal.NotifyContext(cmd.Context(), signals...)
+			cmd.SetContext(ctx)
 
-					return nil
-				},
-				PersistentPostRun: func(cmd *cobra.Command, args []string) {
-					// shutdown through command that is finite (e.g. help command)
-					shutdownOnce.Do(func() {
-						shutdown(eventRouterProvider(), signals, shutdownComplete, logger)
-						<-shutdownComplete
-					})
-				},
-				Example: `Run with -h or -help to see global debug flags`,
-			}
-			//rootCmd.SetHelpTemplate()
-			rootCmd.FParseErrWhitelist.UnknownFlags = true
-			for _, set := range flagSetProvider() {
-				rootCmd.PersistentFlags().AddFlagSet(set)
-			}
+			go func() {
+				// if in the serve command wait for signal to come (context will be cancelled),
+				// then disable listening for signals (calling stop())
+				// then execute shutdown func
+				<-cmd.Context().Done()
 
-			rootCmd.AddCommand(commands...)
+				if stop != nil {
+					stop()
+				}
 
-			return rootCmd
+				execShutdownOnce()
+			}()
 		},
-	).In(dingo.Singleton)
+		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+			// on finished command execution
+			// stop listening for signals by calling stop()
+			// wait for context to be cancelled (should happen immediately after stop())
+			// execute shutdown func
+			if stop != nil {
+				stop()
+			}
+
+			<-cmd.Context().Done()
+
+			execShutdownOnce()
+
+			return err
+		},
+		Example: `Run with -h or -help to see global debug flags`,
+	}
+
+	rootCmd.FParseErrWhitelist.UnknownFlags = true
+	for _, set := range flagSetProvider() {
+		rootCmd.PersistentFlags().AddFlagSet(set)
+	}
+
+	rootCmd.AddCommand(commands...)
+
+	return rootCmd
 }
 
 // CueConfig specifies the command name
@@ -99,27 +125,52 @@ func (*Module) FlamingoLegacyConfigAlias() map[string]string {
 	return map[string]string{"cmd.name": "flamingo.cmd.name"}
 }
 
-func shutdown(eventRouter flamingo.EventRouter, signals <-chan os.Signal, complete chan<- struct{}, logger flamingo.Logger) {
+// shutdown wait for context ctx to be done and dispatches shutdown event
+func shutdown(logger flamingo.Logger, eventRouter flamingo.EventRouter) error {
 	logger.Info("start graceful shutdown")
 
-	stopper := make(chan struct{})
+	var (
+		group   *errgroup.Group
+		sigch   = make(chan os.Signal, 1)
+		stopper = make(chan struct{})
+		timeout = 30 * time.Second
+	)
 
-	go func() {
-		eventRouter.Dispatch(context.Background(), &flamingo.ShutdownEvent{})
-		close(stopper)
-	}()
+	signal.Notify(sigch, signals...)
 
-	select {
-	case <-signals:
-		logger.Info("second interrupt signal received, hard shutdown")
-		os.Exit(130)
-	case <-time.After(30 * time.Second):
-		logger.Info("time limit reached, hard shutdown")
-		os.Exit(130)
-	case <-stopper:
-		logger.Info("graceful shutdown complete")
-		complete <- struct{}{}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	group, ctx = errgroup.WithContext(ctx)
+
+	group.Go(func() error {
+		defer close(stopper)
+
+		eventRouter.Dispatch(ctx, &flamingo.ShutdownEvent{})
+
+		return nil
+	})
+
+	group.Go(func() error {
+		select {
+		case <-sigch:
+			logger.Info("second interrupt signal received, hard shutdown")
+			return fmt.Errorf("%w: signal received", ErrGracefulShutdown)
+		case <-ctx.Done():
+			logger.Info("time limit reached, hard shutdown")
+			return fmt.Errorf("%w: timed out", ErrGracefulShutdown)
+		case <-stopper:
+			logger.Info("graceful shutdown complete")
+			return nil
+		}
+	})
+
+	err := group.Wait()
+	if err != nil {
+		return fmt.Errorf("flamingo shutdown: %w", err)
 	}
+
+	return nil
 }
 
 // Run the root command
@@ -128,12 +179,23 @@ func Run(injector *dingo.Injector) error {
 	if err != nil {
 		return err
 	}
-	cmd := i.(*cobra.Command)
+
+	cmd, ok := i.(*cobra.Command)
+	if !ok {
+		return fmt.Errorf("%w: resolved instance does not have type *cobra.Command", ErrCmdRun)
+	}
+
 	i, err = injector.GetInstance(new(eventRouterProvider))
 	if err != nil {
 		return err
 	}
-	i.(eventRouterProvider)().Dispatch(context.Background(), &flamingo.StartupEvent{})
+
+	erp, ok := i.(eventRouterProvider)
+	if !ok {
+		return fmt.Errorf("%w: resolved instance does not have type eventRouterProvider", ErrCmdRun)
+	}
+
+	erp().Dispatch(cmd.Context(), &flamingo.StartupEvent{})
 
 	return cmd.Execute()
 }

--- a/framework/cmd/module_test.go
+++ b/framework/cmd/module_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"flamingo.me/dingo"
+
 	"flamingo.me/flamingo/v3/framework/cmd"
 )
 


### PR DESCRIPTION
This PR adds some tests to cover command execution and triggering startup and shutdown events. In order to enable testing it introduces some minor refactoring of error handling and graceful shutdown