### PR TITLE
feat: zap logger caller skip configurable

### DIFF
--- a/core/zap/module.go
+++ b/core/zap/module.go
@@ -82,10 +82,10 @@ func (m *Module) Inject(config *struct {
 	m.logSession = config.LogSession
 	m.callerEncoder = callerEncoders[ZapCallerEncoderShort]
 
-	//if not provided set 1 as default
+	// if not provided set 1 as default
 	m.callerskip = 2
 	if config.CallerSkip > 1 {
-		//otherwise let user config override
+		// otherwise let user config override
 		m.callerskip = config.CallerSkip
 	}
 

--- a/core/zap/module.go
+++ b/core/zap/module.go
@@ -83,7 +83,7 @@ func (m *Module) Inject(config *struct {
 	m.callerEncoder = callerEncoders[ZapCallerEncoderShort]
 
 	//if not provided set 1 as default
-	m.callerskip = 1
+	m.callerskip = 2
 	if config.CallerSkip > 1 {
 		//otherwise let user config override
 		m.callerskip = config.CallerSkip

--- a/core/zap/module.go
+++ b/core/zap/module.go
@@ -82,7 +82,7 @@ func (m *Module) Inject(config *struct {
 	m.logSession = config.LogSession
 	m.callerEncoder = callerEncoders[ZapCallerEncoderShort]
 
-	// if not provided set 1 as default
+	// if not provided set 2 as default
 	m.callerskip = 2
 	if config.CallerSkip > 1 {
 		// otherwise let user config override

--- a/core/zap/module.go
+++ b/core/zap/module.go
@@ -217,7 +217,7 @@ core: zap: {
 	encoding: {
 		caller: *"%s" | "%s" | "%s"
 	}
-	callerskip: float64
+	callerskip: float64 | *1
 }
 `, allowedLevels, ZapCallerEncoderShort, ZapCallerEncoderSmart, ZapCallerEncoderFull)
 }

--- a/core/zap/module.go
+++ b/core/zap/module.go
@@ -217,7 +217,7 @@ core: zap: {
 	encoding: {
 		caller: *"%s" | "%s" | "%s"
 	}
-	callerskip: float64 | *1
+	callerskip: float64 | *2
 }
 `, allowedLevels, ZapCallerEncoderShort, ZapCallerEncoderSmart, ZapCallerEncoderFull)
 }

--- a/core/zap/module.go
+++ b/core/zap/module.go
@@ -25,7 +25,7 @@ type (
 		fieldMap           map[string]string
 		logSession         bool
 		callerEncoder      zapcore.CallerEncoder
-		callerskip         int
+		callerskip         float64
 	}
 
 	shutdownEventSubscriber struct {
@@ -69,7 +69,7 @@ func (m *Module) Inject(config *struct {
 	FieldMap           config.Map `inject:"config:core.zap.fieldmap,optional"`
 	LogSession         bool       `inject:"config:core.zap.logsession,optional"`
 	CallerEncoder      string     `inject:"config:core.zap.encoding.caller,optional"`
-	CallerSkip         int        `inject:"config:core.zap.callerskip,optional"`
+	CallerSkip         float64    `inject:"config:core.zap.callerskip,optional"`
 }) {
 	m.area = config.Area
 	m.json = config.JSON
@@ -164,7 +164,7 @@ func (m *Module) createLoggerInstance() *Logger {
 		InitialFields:    nil,
 	}
 
-	logger, err := cfg.Build(zap.AddCallerSkip(m.callerskip))
+	logger, err := cfg.Build(zap.AddCallerSkip(int(m.callerskip)))
 	if err != nil {
 		panic(err)
 	}
@@ -217,6 +217,7 @@ core: zap: {
 	encoding: {
 		caller: *"%s" | "%s" | "%s"
 	}
+	callerskip: float64
 }
 `, allowedLevels, ZapCallerEncoderShort, ZapCallerEncoderSmart, ZapCallerEncoderFull)
 }


### PR DESCRIPTION
as described in https://github.com/i-love-flamingo/flamingo/issues/511

Make zap logger caller skip configurable so source field shows the actual stack level from users application