### PR TITLE
feat: expose helper method to obtain http.Handler from the application

### DIFF
--- a/app.go
+++ b/app.go
@@ -41,6 +41,8 @@ const (
 var (
 	// ErrAppRun is returned when an error occurs during app.Run()
 	ErrAppRun = errors.New("app run error")
+
+	_ http.Handler = new(Application)
 )
 
 type (
@@ -103,7 +105,7 @@ func WithRoutes(routesModule web.RoutesModule) ApplicationOption {
 	}
 }
 
-// WithCustomLogger allows to use custom logger modules for flamingo app, if nothing available default will be used
+// WithCustomLogger allows using custom logger modules for flamingo app, if nothing available default will be used
 func WithCustomLogger(logger dingo.Module) ApplicationOption {
 	return func(config *Application) {
 		config.loggerModule = logger
@@ -290,6 +292,40 @@ func (app *Application) Run() error {
 	return nil
 }
 
+// HTTPHandler returns an http.Handler with wired routes and handlers
+func (app *Application) HTTPHandler() (http.Handler, error) {
+	injector, err := app.area.GetInitializedInjector()
+	if err != nil {
+		return nil, fmt.Errorf("%w: couldn't get initialized injector: %w", ErrAppRun, err)
+	}
+
+	i, err := injector.GetInstance(new(http.Handler))
+	if err != nil {
+		return nil, fmt.Errorf("%w: couldn't get http.Handler: %w", ErrAppRun, err)
+	}
+
+	handler, ok := i.(http.Handler)
+	if !ok {
+		return nil, fmt.Errorf("%w: resolved type for a handler is not http.Handler", ErrAppRun)
+	}
+
+	return handler, nil
+}
+
+// ServeHTTP makes Application to a valid http.Handler
+func (app *Application) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	if app == nil {
+		return
+	}
+
+	handler, err := app.HTTPHandler()
+	if err != nil {
+		return
+	}
+
+	handler.ServeHTTP(writer, request)
+}
+
 func typeName(of reflect.Type) string {
 	var name string
 
@@ -405,11 +441,13 @@ func (sm *servemodule) Inject(
 func (sm *servemodule) Configure(injector *dingo.Injector) {
 	flamingo.BindEventSubscriber(injector).ToInstance(sm)
 
-	injector.BindMulti(new(cobra.Command)).ToProvider(func(opts *struct {
+	injector.Bind(new(http.Handler)).ToProvider(func(opts *struct {
 		Handler flamingoHttp.HandlerWrapper `inject:",optional"`
-	}) *cobra.Command {
-		return sm.serveProvider(opts.Handler)
+	}) http.Handler {
+		return sm.handlerProvider(opts.Handler)
 	})
+
+	injector.BindMulti(new(cobra.Command)).ToProvider(sm.serveProvider)
 }
 
 // CueConfig for the module
@@ -417,7 +455,19 @@ func (sm *servemodule) CueConfig() string {
 	return `core: serve: port: >= 0 & <= 65535 | *3322`
 }
 
-func (sm *servemodule) serveProvider(handlerWrapper flamingoHttp.HandlerWrapper) *cobra.Command {
+func (sm *servemodule) handlerProvider(handlerWrapper flamingoHttp.HandlerWrapper) http.Handler {
+	sm.mu.Lock()
+	sm.mu.Unlock()
+
+	var handler = sm.router.Handler()
+	if handlerWrapper != nil {
+		handler = handlerWrapper(handler)
+	}
+
+	return handler
+}
+
+func (sm *servemodule) serveProvider(handler http.Handler) *cobra.Command {
 	serveCmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Default serve command - starts on Port 3322",
@@ -426,10 +476,7 @@ func (sm *servemodule) serveProvider(handlerWrapper flamingoHttp.HandlerWrapper)
 				sm.mu.Lock()
 				defer sm.mu.Unlock()
 
-				sm.server.Handler = sm.router.Handler()
-				if handlerWrapper != nil {
-					sm.server.Handler = handlerWrapper(sm.server.Handler)
-				}
+				sm.server.Handler = handler
 			}()
 
 			err := sm.listenAndServe()

--- a/app.go
+++ b/app.go
@@ -41,6 +41,8 @@ const (
 var (
 	// ErrAppRun is returned when an error occurs during app.Run()
 	ErrAppRun = errors.New("app run error")
+
+	_ http.Handler = new(Application)
 )
 
 type (
@@ -55,6 +57,7 @@ type (
 		defaultContext  string
 		eagerSingletons bool
 		flagset         *flag.FlagSet
+		onceHandler     func() (http.Handler, error)
 	}
 
 	// ApplicationOption configures an Application
@@ -68,7 +71,7 @@ func ConfigDir(configdir string) ApplicationOption {
 	}
 }
 
-// ChildAreas allows to define additional config areas for roots
+// ChildAreas allows defining additional config areas for roots
 func ChildAreas(areas ...*config.Area) ApplicationOption {
 	return func(config *Application) {
 		config.childAreas = areas
@@ -82,7 +85,7 @@ func DefaultContext(name string) ApplicationOption {
 	}
 }
 
-// SetEagerSingletons controls if eager singletons will be created
+// SetEagerSingletons controls if eager singletons are created
 func SetEagerSingletons(enabled bool) ApplicationOption {
 	return func(config *Application) {
 		config.eagerSingletons = enabled
@@ -103,7 +106,7 @@ func WithRoutes(routesModule web.RoutesModule) ApplicationOption {
 	}
 }
 
-// WithCustomLogger allows to use custom logger modules for flamingo app, if nothing available default will be used
+// WithCustomLogger allows using custom logger modules for flamingo app, if nothing available default will be used
 func WithCustomLogger(logger dingo.Module) ApplicationOption {
 	return func(config *Application) {
 		config.loggerModule = logger
@@ -224,6 +227,8 @@ func NewApplication(modules []dingo.Module, options ...ApplicationOption) (*Appl
 		}
 	}
 
+	app.onceHandler = sync.OnceValues(app.HTTPHandler)
+
 	return app, nil
 }
 
@@ -288,6 +293,40 @@ func (app *Application) Run() error {
 	}
 
 	return nil
+}
+
+// HTTPHandler returns an http.Handler with wired routes and handlers
+func (app *Application) HTTPHandler() (http.Handler, error) {
+	injector, err := app.area.GetInitializedInjector()
+	if err != nil {
+		return nil, fmt.Errorf("%w: couldn't get initialized injector: %w", ErrAppRun, err)
+	}
+
+	i, err := injector.GetInstance(new(http.Handler))
+	if err != nil {
+		return nil, fmt.Errorf("%w: couldn't get http.Handler: %w", ErrAppRun, err)
+	}
+
+	handler, ok := i.(http.Handler)
+	if !ok {
+		return nil, fmt.Errorf("%w: resolved type for a handler is not http.Handler", ErrAppRun)
+	}
+
+	return handler, nil
+}
+
+// ServeHTTP makes Application to a valid http.Handler
+func (app *Application) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	if app == nil {
+		return
+	}
+
+	handler, err := app.onceHandler()
+	if err != nil {
+		return
+	}
+
+	handler.ServeHTTP(writer, request)
 }
 
 func typeName(of reflect.Type) string {
@@ -405,11 +444,13 @@ func (sm *servemodule) Inject(
 func (sm *servemodule) Configure(injector *dingo.Injector) {
 	flamingo.BindEventSubscriber(injector).ToInstance(sm)
 
-	injector.BindMulti(new(cobra.Command)).ToProvider(func(opts *struct {
+	injector.Bind(new(http.Handler)).ToProvider(func(opts *struct {
 		Handler flamingoHttp.HandlerWrapper `inject:",optional"`
-	}) *cobra.Command {
-		return sm.serveProvider(opts.Handler)
+	}) http.Handler {
+		return sm.handlerProvider(opts.Handler)
 	})
+
+	injector.BindMulti(new(cobra.Command)).ToProvider(sm.serveProvider)
 }
 
 // CueConfig for the module
@@ -417,7 +458,19 @@ func (sm *servemodule) CueConfig() string {
 	return `core: serve: port: >= 0 & <= 65535 | *3322`
 }
 
-func (sm *servemodule) serveProvider(handlerWrapper flamingoHttp.HandlerWrapper) *cobra.Command {
+func (sm *servemodule) handlerProvider(handlerWrapper flamingoHttp.HandlerWrapper) http.Handler {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	var handler = sm.router.Handler()
+	if handlerWrapper != nil {
+		handler = handlerWrapper(handler)
+	}
+
+	return handler
+}
+
+func (sm *servemodule) serveProvider(handler http.Handler) *cobra.Command {
 	serveCmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Default serve command - starts on Port 3322",
@@ -426,10 +479,7 @@ func (sm *servemodule) serveProvider(handlerWrapper flamingoHttp.HandlerWrapper)
 				sm.mu.Lock()
 				defer sm.mu.Unlock()
 
-				sm.server.Handler = sm.router.Handler()
-				if handlerWrapper != nil {
-					sm.server.Handler = handlerWrapper(sm.server.Handler)
-				}
+				sm.server.Handler = handler
 			}()
 
 			err := sm.listenAndServe()
@@ -450,7 +500,7 @@ func (sm *servemodule) serveProvider(handlerWrapper flamingoHttp.HandlerWrapper)
 }
 
 func (sm *servemodule) listenAndServe() error {
-	listener, err := net.Listen("tcp", sm.server.Addr)
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", sm.server.Addr)
 	if err != nil {
 		return fmt.Errorf("flamingo: failed to listen: %w", err)
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -11,6 +13,7 @@ import (
 	"time"
 
 	"flamingo.me/dingo"
+	"flamingo.me/flamingo/v3/framework/web"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -254,4 +257,43 @@ func TestGracefulShutdown(t *testing.T) { //nolint:paralleltest // due to dingo.
 			tt.assertShutdownCount(t, shutdownEventCount.Load())
 		})
 	}
+}
+
+func TestHandler(t *testing.T) {
+	t.Parallel()
+
+	modules := []dingo.Module{
+		dingo.ModuleFunc(func(injector *dingo.Injector) {
+			web.BindRoutes(injector, new(routes))
+		}),
+	}
+
+	app, err := flamingo.NewApplication(modules, flamingo.WithArgs(""))
+	require.NoError(t, err)
+
+	handler, err := app.HTTPHandler()
+	if assert.NoError(t, err) {
+		assert.NotNil(t, handler)
+	}
+
+	testServer := httptest.NewServer(handler)
+	defer testServer.Close()
+
+	requestURL := fmt.Sprintf("%s/hello", testServer.URL)
+	response, err := testServer.Client().Get(requestURL)
+	if assert.NoError(t, err) {
+		assert.Equal(t, http.StatusTeapot, response.StatusCode)
+	}
+}
+
+type routes struct {
+}
+
+func (r *routes) Routes(registry *web.RouterRegistry) {
+	_, _ = registry.Route("/hello", "hello")
+	registry.HandleGet("hello", func(ctx context.Context, req *web.Request) web.Result {
+		return &web.Response{
+			Status: http.StatusTeapot,
+		}
+	})
 }

--- a/app_test.go
+++ b/app_test.go
@@ -179,12 +179,12 @@ func TestGracefulShutdown(t *testing.T) { //nolint:paralleltest // due to dingo.
 			insideCommandRun: func(cmd *cobra.Command, args []string) {
 				send := buildSignalSender(t)
 				send()
-				time.Sleep(time.Millisecond)
+				time.Sleep(time.Second) // test is flaky because it relies on the signal handling happening within a speculated time frame and needs to be refactored
 				send()
 			},
 			onShutdown: sync.OnceFunc(func() {
 				// artificial delay, so that second interrupt could arrive
-				time.Sleep(time.Second)
+				time.Sleep(5 * time.Second)
 			}),
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				return assert.ErrorIs(t, err, cmd.ErrGracefulShutdown)

--- a/app_test.go
+++ b/app_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -11,9 +13,11 @@ import (
 	"time"
 
 	"flamingo.me/dingo"
+	"flamingo.me/flamingo/v3/framework/web"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	"flamingo.me/flamingo/v3"
 	"flamingo.me/flamingo/v3/framework/cmd"
@@ -230,9 +234,15 @@ func TestGracefulShutdown(t *testing.T) { //nolint:paralleltest // due to dingo.
 							notifyFunc(func(ctx context.Context, event framework.Event) {
 								switch ev := event.(type) {
 								case *framework.ServerStartEvent:
-									if _, err := net.Dial("tcp", fmt.Sprintf(":%s", ev.Port)); err != nil {
+									dialCtx, cancel := context.WithTimeout(ctx, time.Second)
+									defer cancel()
+
+									conn, err := (&net.Dialer{}).DialContext(dialCtx, "tcp", fmt.Sprintf(":%s", ev.Port))
+									if err != nil {
 										t.Fatalf("failed to connect to server")
 									}
+
+									_ = conn.Close()
 
 									tt.onServerStartup()
 								case *framework.ShutdownEvent:
@@ -254,4 +264,91 @@ func TestGracefulShutdown(t *testing.T) { //nolint:paralleltest // due to dingo.
 			tt.assertShutdownCount(t, shutdownEventCount.Load())
 		})
 	}
+}
+
+func TestHandler(t *testing.T) { //nolint:paralleltest // dingo singleton scopes are process-wide and shared between application tests
+	runConcurrentRequests := func(ctx context.Context, client *http.Client, requestURL string) error {
+		g, reqCtx := errgroup.WithContext(ctx)
+		g.SetLimit(8)
+
+		for range 32 {
+			g.Go(func() error {
+				req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, requestURL, nil)
+				if err != nil {
+					return err
+				}
+
+				response, err := client.Do(req)
+				if err != nil {
+					return err
+				}
+				defer response.Body.Close()
+
+				if response.StatusCode != http.StatusTeapot {
+					return fmt.Errorf("unexpected status code: got %d want %d", response.StatusCode, http.StatusTeapot)
+				}
+
+				return nil
+			})
+		}
+
+		return g.Wait()
+	}
+
+	t.Run("use helper method", func(t *testing.T) { //nolint:paralleltest // dingo singleton scopes are process-wide and shared between application tests
+		dingo.Singleton = dingo.NewSingletonScope()
+		dingo.ChildSingleton = dingo.NewChildSingletonScope()
+
+		modules := []dingo.Module{
+			dingo.ModuleFunc(func(injector *dingo.Injector) {
+				web.BindRoutes(injector, new(routes))
+			}),
+		}
+
+		app, err := flamingo.NewApplication(modules, flamingo.WithArgs(""))
+		require.NoError(t, err)
+
+		handler, err := app.HTTPHandler()
+		if assert.NoError(t, err) {
+			assert.NotNil(t, handler)
+		}
+
+		testServer := httptest.NewServer(handler)
+		defer testServer.Close()
+
+		requestURL := fmt.Sprintf("%s/hello", testServer.URL)
+		require.NoError(t, runConcurrentRequests(t.Context(), testServer.Client(), requestURL))
+	})
+
+	t.Run("use instance directly", func(t *testing.T) { //nolint:paralleltest // dingo singleton scopes are process-wide and shared between application tests
+		dingo.Singleton = dingo.NewSingletonScope()
+		dingo.ChildSingleton = dingo.NewChildSingletonScope()
+
+		modules := []dingo.Module{
+			dingo.ModuleFunc(func(injector *dingo.Injector) {
+				web.BindRoutes(injector, new(routes))
+			}),
+		}
+
+		app, err := flamingo.NewApplication(modules, flamingo.WithArgs(""))
+		require.NoError(t, err)
+
+		testServer := httptest.NewServer(app)
+		defer testServer.Close()
+
+		requestURL := fmt.Sprintf("%s/hello", testServer.URL)
+		require.NoError(t, runConcurrentRequests(t.Context(), testServer.Client(), requestURL))
+	})
+}
+
+type routes struct {
+}
+
+func (r *routes) Routes(registry *web.RouterRegistry) {
+	_, _ = registry.Route("/hello", "hello")
+	registry.HandleGet("hello", func(ctx context.Context, req *web.Request) web.Result {
+		return &web.Response{
+			Status: http.StatusTeapot,
+		}
+	})
 }

--- a/core/auth/oauth/oidc.go
+++ b/core/auth/oauth/oidc.go
@@ -539,6 +539,7 @@ func (i *openIDIdentifier) Callback(ctx context.Context, request *web.Request, r
 	if len(accessTokenParts) >= 2 {
 		decoded, _ := base64.RawURLEncoding.DecodeString(accessTokenParts[1])
 		var cs map[string]interface{}
+
 		_ = json.NewDecoder(bytes.NewBuffer(decoded)).Decode(&cs)
 		if cs != nil {
 			for k, v := range i.oidcConfig.Claims.AccessToken {

--- a/core/auth/oauth/oidc_test.go
+++ b/core/auth/oauth/oidc_test.go
@@ -217,6 +217,7 @@ func TestOidcCallback(t *testing.T) {
 		}
 
 		var err error
+
 		identifier.provider, err = oidc.NewProvider(context.Background(), testserver.URL)
 		assert.NoError(t, err)
 
@@ -275,6 +276,7 @@ func TestOidcCallback(t *testing.T) {
 		}
 
 		var err error
+
 		identifier.provider, err = oidc.NewProvider(context.Background(), testserver.URL)
 		assert.NoError(t, err)
 
@@ -308,6 +310,7 @@ func TestOidcCallback(t *testing.T) {
 			switch strings.Trim(r.URL.Path, "/") {
 			case "token":
 				{
+					r.Body = http.MaxBytesReader(w, r.Body, 1024)
 					_ = r.ParseForm()
 					redirectURI := r.PostForm.Get("redirect_uri")
 
@@ -329,6 +332,7 @@ func TestOidcCallback(t *testing.T) {
 		})
 
 		testServer.Config.Handler = handler
+
 		testServer.Start()
 		defer testServer.Close()
 
@@ -341,6 +345,7 @@ func TestOidcCallback(t *testing.T) {
 		}
 
 		var err error
+
 		identifier.provider, err = oidc.NewProvider(context.Background(), testServer.URL)
 		assert.NoError(t, err)
 

--- a/core/cache/httpFrontend.go
+++ b/core/cache/httpFrontend.go
@@ -19,8 +19,9 @@ type (
 	// HTTPLoader returns a response. it will be cached unless there is an error. this means 400/500 responses are cached too!
 	HTTPLoader func(context.Context) (*http.Response, *Meta, error)
 
-	// HTTPFrontend stores and caches http responses
-	// Deprecated: Please use the dedicated httpcache flamingo module, see here: flamingo.me/httpcache
+	// HTTPFrontend stores and caches http responses.
+	//
+	// Deprecated: Please use the dedicated httpcache flamingo module, see here: flamingo.me/httpcache.
 	HTTPFrontend struct {
 		singleflight.Group
 		backend Backend

--- a/framework/cmd/module.go
+++ b/framework/cmd/module.go
@@ -71,6 +71,7 @@ func RootCommandProvider(
 		TraverseChildren: true,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			var ctx context.Context
+
 			ctx, stop = signal.NotifyContext(cmd.Context(), signals...)
 			cmd.SetContext(ctx)
 

--- a/framework/flamingo/log_test.go
+++ b/framework/flamingo/log_test.go
@@ -12,6 +12,7 @@ import (
 
 func createLogger(recorder io.Writer) flamingo.Logger {
 	var l = new(flamingo.StdLogger)
+
 	l.Logger = *log.New(recorder, "TEST--", 0)
 
 	return l

--- a/framework/flamingo/sessions.go
+++ b/framework/flamingo/sessions.go
@@ -122,7 +122,6 @@ func (m *SessionModule) Inject(
 
 	if config.RedisTimeout != "" {
 		redisTimeout, err := time.ParseDuration(config.RedisTimeout)
-
 		if err != nil {
 			panic(fmt.Errorf("invalid duration on %q: %q (%w)", "flamingo.session.redis.timeout", config.RedisTimeout, err))
 		}
@@ -358,6 +357,7 @@ func getRedisDatabase(redisURL *url.URL, redisDatabase int) int {
 	var err error
 
 	redisDatabaseFromPath := strings.Trim(redisURL.Path, "/")
+
 	redisDatabaseFromQuery := redisURL.Query().Get("db")
 	if len(redisDatabaseFromPath) > 0 {
 		redisDatabase, err = strconv.Atoi(redisDatabaseFromPath)

--- a/framework/module.go
+++ b/framework/module.go
@@ -1,11 +1,15 @@
 // Package framework provides the most necessary basics, such as
-//   - service_locator
-//   - router
-//   - web (including context and response)
+//
+//   - Service_locator
+//
+//   - Router
+//
+//   - Web (including context and response)
+//
 //   - web/responder
 //
-// Additionally it provides a router at /_flamingo/json/{handler} for convenient access to DataControllers
-// Additionally it registers two template functions, `get(...)` and `url(...)`
+//     Additionally, it provides a router at /_flamingo/json/{handler} for convenient access to DataControllers
+//     Additionally, it registers two template functions, `get(...)` and `url(...)`
 package framework
 
 import (

--- a/framework/opencensus/module.go
+++ b/framework/opencensus/module.go
@@ -55,6 +55,7 @@ func (rt *correlationIDInjector) RoundTrip(req *http.Request) (*http.Response, e
 }
 
 // Module registers the opencensus module which in turn enables jaeger & co.
+//
 // Deprecated: OpenCensus was discontinued in favor of OpenTelemetry, please use flamingo.me/opentelemetry instead.
 type Module struct {
 	publicEndpoint bool

--- a/framework/testutil/pact.go
+++ b/framework/testutil/pact.go
@@ -1,5 +1,6 @@
-// Package testutil contains helper functions for PACT testing
-// Deprecated: PACT support will be dropped from Flamingo in v4
+// Package testutil contains helper functions for PACT testing.
+//
+// Deprecated: PACT support will be dropped from Flamingo in v4.
 package testutil
 
 import (
@@ -19,12 +20,14 @@ import (
 	"github.com/pact-foundation/pact-go/types"
 )
 
-// ErrNoPact error
-// Deprecated: PACT support will be dropped from Flamingo in v4
+// ErrNoPact error.
+//
+// Deprecated: PACT support will be dropped from Flamingo in v4.
 var ErrNoPact = errors.New("no pact setup")
 
-// WithPact runs a test with a pact
-// Deprecated: PACT support will be dropped from Flamingo in v4
+// WithPact runs a test with a pact.
+//
+// Deprecated: PACT support will be dropped from Flamingo in v4.
 func WithPact(t *testing.T, from, to string, fs ...func(*testing.T, *dsl.Pact)) {
 	if from == "" {
 		from = "flamingo"
@@ -111,8 +114,9 @@ func pactTeardown(pact *dsl.Pact) error {
 	return nil
 }
 
-// PactEncodeLike encodes a byte slice from json.Marshal or jsonpb into a pact type-like representation
-// Deprecated: PACT support will be dropped from Flamingo in v4
+// PactEncodeLike encodes a byte slice from json.Marshal or jsonpb into a pact type-like representation.
+//
+// Deprecated: PACT support will be dropped from Flamingo in v4.
 func PactEncodeLike(model []byte) string {
 	var data interface{}
 	json.Unmarshal(model, &data)

--- a/framework/web/router.go
+++ b/framework/web/router.go
@@ -16,14 +16,14 @@ import (
 )
 
 type (
-	// ReverseRouter allows to retrieve urls for controller
+	// ReverseRouter allows retrieving URLs for a controller
 	ReverseRouter interface {
 		// Relative returns a root-relative URL, starting with `/`
-		// if to starts with "/" it will be used as the target, instead of resolving the URL
+		// if `to` starts with "/", it will be used as the target, instead of resolving the URL
 		Relative(to string, params map[string]string) (*url.URL, error)
 		// Absolute returns an absolute URL, with scheme and host.
-		// It takes the request to construct as many information as possible
-		// if to starts with "/" it will be used as the target, instead of resolving the URL
+		// It takes the request to construct as much information as possible
+		// if `to` starts with "/" it will be used as the target, instead of resolving the URL
 		Absolute(r *Request, to string, params map[string]string) (*url.URL, error)
 	}
 
@@ -31,7 +31,7 @@ type (
 	routesProvider    func() []RoutesModule
 	responderProvider func() *Responder
 
-	// Router represents actual implementation of ReverseRouter interface
+	// Router represents the actual implementation of ReverseRouter interface
 	Router struct {
 		base              *url.URL
 		external          *url.URL
@@ -102,7 +102,7 @@ func (r *Router) Inject(
 	r.responderProvider = responderProvider
 }
 
-// Handler creates and returns new instance of http.Handler interface
+// Handler creates and returns a new instance of http.Handler interface
 func (r *Router) Handler() http.Handler {
 	r.routerRegistry = NewRegistry()
 


### PR DESCRIPTION
The Go standard library provides convenient web server testing facilities via httptest.Server. This PR introduces a helper method to obtain an http.Handler from the configured flamingo.Application. It also makes the Application itself an http.Handler by implementing ServeHTTP method. This allows following usage in tests:

```go
	app, err := flamingo.NewApplication(modules, ...)
	if err != nil { ... }

	handler, err := app.HTTPHandler()
	if err != nil { ... }

	testServer := httptest.NewServer(handler) // or even httptest.NewServer(app)
	defer testServer.Close()

	requestURL := fmt.Sprintf("%s/hello", testServer.URL)
	response, err := testServer.Client().Get(requestURL)
	if assert.NoError(t, err) {
		...
	}
```