### PR TITLE
fix(framework/web): do not expose partial rendering errors

### DIFF
--- a/framework/web/result.go
+++ b/framework/web/result.go
@@ -357,17 +357,23 @@ func (r *RenderResponse) Apply(c context.Context, w http.ResponseWriter) error {
 			for k, v := range content {
 				buf, err := io.ReadAll(v)
 				if err != nil {
-					return err
+					w.WriteHeader(http.StatusInternalServerError)
+
+					return ErrPartialRenderingFailed
 				}
 				result[k] = string(buf)
 			}
 
 			body, err := json.Marshal(map[string]interface{}{"partials": result, "data": new(GetPartialDataFunc).Func(c).(func() map[string]interface{})()})
 			if err != nil {
-				return err
+				w.WriteHeader(http.StatusInternalServerError)
+
+				return ErrPartialRenderingFailed
 			}
+
 			r.Body = bytes.NewBuffer(body)
 			r.Header.Set("Content-Type", "application/json; charset=utf-8")
+
 			return r.Response.Apply(c, w)
 		}
 	}
@@ -375,11 +381,16 @@ func (r *RenderResponse) Apply(c context.Context, w http.ResponseWriter) error {
 	if r.Header == nil {
 		r.Header = make(http.Header)
 	}
+
 	r.Header.Set("Content-Type", "text/html; charset=utf-8")
+
 	r.Body, err = r.engine.Render(c, r.Template, r.Data)
 	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+
 		return err
 	}
+
 	return r.Response.Apply(c, w)
 }
 

--- a/framework/web/result.go
+++ b/framework/web/result.go
@@ -344,7 +344,9 @@ func (r *RenderResponse) Apply(c context.Context, w http.ResponseWriter) error {
 		if partials := req.Request().Header.Get("X-Partial"); partials != "" && ok {
 			content, err := partialRenderer.RenderPartials(c, r.Template, r.Data, strings.Split(partials, ","))
 			if err != nil {
-				return err
+				w.WriteHeader(http.StatusInternalServerError)
+
+				return fmt.Errorf("failed to render partials")
 			}
 
 			result := make(map[string]string, len(content))

--- a/framework/web/result.go
+++ b/framework/web/result.go
@@ -124,6 +124,10 @@ const (
 	CacheVisibilityPublic = "public"
 )
 
+var (
+	ErrPartialRenderingFailed = fmt.Errorf("failed to render partials")
+)
+
 // Inject Responder dependencies
 func (r *Responder) Inject(router *Router, logger flamingo.Logger, cfg *struct {
 	Engine                flamingo.TemplateEngine `inject:",optional"`
@@ -346,7 +350,7 @@ func (r *RenderResponse) Apply(c context.Context, w http.ResponseWriter) error {
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 
-				return fmt.Errorf("failed to render partials")
+				return ErrPartialRenderingFailed
 			}
 
 			result := make(map[string]string, len(content))


### PR DESCRIPTION
Any client or attacker can freely set the `X-Partial` header. We should not expose the real template engine error and only respond with a general failure.

A classical example for an attack can be: `X-Partial: (select(0)from(select(sleep(15)))v)/*'\''+(select(0)from(select(sleep(15)))v)+'\''"+(select(0)from(select(sleep(15)))v)+"'`